### PR TITLE
Dd 35 프로필 조회 API

### DIFF
--- a/src/main/java/com/dodok/honeypot/domain/member/dto/info/MemberInfo.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/dto/info/MemberInfo.java
@@ -3,6 +3,7 @@ package com.dodok.honeypot.domain.member.dto.info;
 public record MemberInfo(
     Long memberId,
     String name,
-    String email
+    String email,
+    String imageUrl
 ) {
 }

--- a/src/main/java/com/dodok/honeypot/domain/member/dto/res/MemberInfoResDto.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/dto/res/MemberInfoResDto.java
@@ -1,8 +1,16 @@
 package com.dodok.honeypot.domain.member.dto.res;
 
+import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
 public record MemberInfoResDto(
-        String name,
-        String email,
-        String imageUrl
+        MemberInfo memberInfo
 ){
+    public static MemberInfoResDto of(MemberInfo memberInfo) {
+        return MemberInfoResDto.builder()
+                .memberInfo(memberInfo)
+                .build();
+    }
 }

--- a/src/main/java/com/dodok/honeypot/domain/member/helper/MemberHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/helper/MemberHelper.java
@@ -1,7 +1,6 @@
 package com.dodok.honeypot.domain.member.helper;
 
 import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
-import com.dodok.honeypot.domain.member.dto.res.MemberInfoResDto;
 import com.dodok.honeypot.domain.member.repository.MemberRepository;
 import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +16,8 @@ public class MemberHelper {
 
     private final MemberRepository memberRepository;
 
-    public MemberInfoResDto findMemberByIdOrElseThrow(Long memberId) {
-        return memberRepository.findMemberById(memberId)
+    public MemberInfo findMemberByIdOrElseThrow(Long memberId) {
+        return memberRepository.findMemberDetailInfoByMemberId(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(MEMBER_ENTITY_NOT_FOUND));
     }
 

--- a/src/main/java/com/dodok/honeypot/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.dodok.honeypot.domain.member.mapper;
 
 import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
+import com.dodok.honeypot.domain.member.dto.res.MemberInfoResDto;
 import com.dodok.honeypot.domain.member.dto.res.MembersInfoResDto;
 import com.dodok.honeypot.global.dto.PageInfo;
 import org.springframework.data.domain.Page;
@@ -8,6 +9,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MemberMapper {
+
+    public MemberInfoResDto toMemberInfoResDto(MemberInfo memberInfo) {
+        return MemberInfoResDto.of(memberInfo);
+    }
 
     public MembersInfoResDto toMemberGetResDto(Page<MemberInfo> memberInfoPage) {
         PageInfo pageInfo = PageInfo.of(memberInfoPage);

--- a/src/main/java/com/dodok/honeypot/domain/member/repository/MemberDetailInfoQueryRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/repository/MemberDetailInfoQueryRepository.java
@@ -1,0 +1,9 @@
+package com.dodok.honeypot.domain.member.repository;
+
+import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
+
+import java.util.Optional;
+
+public interface MemberDetailInfoQueryRepository {
+    Optional<MemberInfo> findMemberDetailInfoByMemberId(Long memberId);
+}

--- a/src/main/java/com/dodok/honeypot/domain/member/repository/MemberDetailInfoQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/repository/MemberDetailInfoQueryRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.dodok.honeypot.domain.member.repository;
+
+import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.dodok.honeypot.domain.member.entity.QMember.member;
+import static com.dodok.honeypot.domain.member.entity.QProfileImage.profileImage;
+
+@RequiredArgsConstructor
+public class MemberDetailInfoQueryRepositoryImpl implements MemberDetailInfoQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<MemberInfo> findMemberDetailInfoByMemberId(Long memberId) {
+        return Optional.ofNullable(queryFactory.
+                select(Projections.constructor(MemberInfo.class,
+                        member.id,
+                        member.name,
+                        member.email,
+                        member.imageUrl.coalesce(profileImage.imageUrl)
+                ))
+                .from(member)
+                .leftJoin(member.profileImage, profileImage)
+                .where(eqMemberId(memberId))
+                .fetchOne());
+    }
+
+    private static BooleanExpression eqMemberId(Long memberId) {
+        return member.id.eq(memberId);
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/repository/MemberRepository.java
@@ -1,14 +1,11 @@
 package com.dodok.honeypot.domain.member.repository;
 
-import com.dodok.honeypot.domain.member.dto.res.MemberInfoResDto;
 import com.dodok.honeypot.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberGetInfoQueryRepository {
-
-    Optional<MemberInfoResDto> findMemberById(Long memberId);
+public interface MemberRepository extends JpaRepository<Member, Long>,
+        MemberGetInfoQueryRepository,
+        MemberDetailInfoQueryRepository {
 }

--- a/src/main/java/com/dodok/honeypot/domain/member/service/GetMemberInfoService.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/service/GetMemberInfoService.java
@@ -1,8 +1,10 @@
 package com.dodok.honeypot.domain.member.service;
 
 
+import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
 import com.dodok.honeypot.domain.member.dto.res.MemberInfoResDto;
 import com.dodok.honeypot.domain.member.helper.MemberHelper;
+import com.dodok.honeypot.domain.member.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,8 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class GetMemberInfoService {
     private final MemberHelper memberHelper;
+    private final MemberMapper memberMapper;
 
     public MemberInfoResDto execute(Long memberId) {
-        return memberHelper.findMemberByIdOrElseThrow(memberId);
+        MemberInfo memberInfo = memberHelper.findMemberByIdOrElseThrow(memberId);
+        return memberMapper.toMemberInfoResDto(memberInfo);
     }
 }


### PR DESCRIPTION
## 📝 작업내용
- 유저 자신의 프로필 조회 API를 만들었습니다.

## 💬 중점적으로 봐줄 사항
- 아직 accessToken을 통해 memberId를 꺼내는 로직이 없는 관계로 PathVariable로 memberId를 받아오는 걸로 구현했습니다. 추후 토큰부분 작업 완료되면 수정하도록 하겠습니다.
- COALESCE를 통해 멤버 컬럼의 imageUrl이 비어있으면 ProfileImage를 통해 imageUrl을 받아오도록 쿼리를 작성했습니다.
- 테스트 코드도 아직 없는데 테스트 코드 설정이 완료되면 진행하도록 하겠습니다.
