### PR TITLE
Dd 36 프로필 수정 API

### DIFF
--- a/src/main/java/com/dodok/honeypot/application/member/controller/MemberController.java
+++ b/src/main/java/com/dodok/honeypot/application/member/controller/MemberController.java
@@ -1,9 +1,11 @@
 package com.dodok.honeypot.application.member.controller;
 
+import com.dodok.honeypot.domain.member.dto.req.MemberUpdateReqDto;
 import com.dodok.honeypot.domain.member.dto.res.MemberInfoResDto;
 import com.dodok.honeypot.domain.member.dto.res.MembersInfoResDto;
 import com.dodok.honeypot.domain.member.service.GetMemberInfoService;
 import com.dodok.honeypot.domain.member.service.GetMembersInfoService;
+import com.dodok.honeypot.domain.member.service.UpdateMemberInfoService;
 import com.dodok.honeypot.global.dto.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
     private final GetMembersInfoService getMembersInfoService;
     private final GetMemberInfoService getMemberInfoService;
+    private final UpdateMemberInfoService updateMemberInfoService;
 
     @GetMapping("/info/{id}")
     public ResponseEntity<SuccessResponse<?>> getMemberInfo(@PathVariable("id") final Long memberId) {
@@ -28,5 +31,12 @@ public class MemberController {
                                                             final Pageable pageable) {
         final MembersInfoResDto response = getMembersInfoService.execute(name, pageable);
         return SuccessResponse.ok(response);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<SuccessResponse<?>> updateMemberInfo(@PathVariable("id") final Long memberId,
+                                                               @RequestBody final MemberUpdateReqDto requestDto) {
+        updateMemberInfoService.execute(memberId, requestDto);
+        return SuccessResponse.ok(null);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/member/dto/req/MemberUpdateReqDto.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/dto/req/MemberUpdateReqDto.java
@@ -1,0 +1,7 @@
+package com.dodok.honeypot.domain.member.dto.req;
+
+public record MemberUpdateReqDto (
+        String name,
+        Long profileImageId
+){
+}

--- a/src/main/java/com/dodok/honeypot/domain/member/entity/Member.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/entity/Member.java
@@ -5,6 +5,8 @@ import com.dodok.honeypot.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import static com.dodok.honeypot.global.utils.UpdateValueUtils.updateValue;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
@@ -33,5 +35,10 @@ public class Member extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "profile_image_id")
     private ProfileImage profileImage;
+
+    public void updateMember(String name, ProfileImage profileImage) {
+        this.name = updateValue(this.name, name);
+        this.profileImage = updateValue(this.profileImage, profileImage);
+    }
 }
 

--- a/src/main/java/com/dodok/honeypot/domain/member/error/ProfileImageErrorCode.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/error/ProfileImageErrorCode.java
@@ -1,0 +1,21 @@
+package com.dodok.honeypot.domain.member.error;
+
+import com.dodok.honeypot.global.error.code.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum ProfileImageErrorCode implements ErrorCode {
+
+    /**
+     * 404 Not Found
+     */
+    PROFILE_IMAGE_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 프로필 이미지를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/dodok/honeypot/domain/member/helper/MemberHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/helper/MemberHelper.java
@@ -16,7 +16,7 @@ public class MemberHelper {
 
     private final MemberRepository memberRepository;
 
-    public MemberInfo findMemberByIdOrElseThrow(Long memberId) {
+    public MemberInfo findMemberInfoByIdOrElseThrow(Long memberId) {
         return memberRepository.findMemberDetailInfoByMemberId(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(MEMBER_ENTITY_NOT_FOUND));
     }

--- a/src/main/java/com/dodok/honeypot/domain/member/helper/MemberHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/helper/MemberHelper.java
@@ -1,6 +1,7 @@
 package com.dodok.honeypot.domain.member.helper;
 
 import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
+import com.dodok.honeypot.domain.member.entity.Member;
 import com.dodok.honeypot.domain.member.repository.MemberRepository;
 import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,11 @@ public class MemberHelper {
 
     public MemberInfo findMemberInfoByIdOrElseThrow(Long memberId) {
         return memberRepository.findMemberDetailInfoByMemberId(memberId)
+                .orElseThrow(() -> new EntityNotFoundException(MEMBER_ENTITY_NOT_FOUND));
+    }
+
+    public Member findMemberByIdOrElseThrow(Long memberId) {
+        return memberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException(MEMBER_ENTITY_NOT_FOUND));
     }
 

--- a/src/main/java/com/dodok/honeypot/domain/member/helper/ProfileImageHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/helper/ProfileImageHelper.java
@@ -1,0 +1,20 @@
+package com.dodok.honeypot.domain.member.helper;
+
+import com.dodok.honeypot.domain.member.entity.ProfileImage;
+import com.dodok.honeypot.domain.member.repository.ProfileImageRepository;
+import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.dodok.honeypot.domain.member.error.ProfileImageErrorCode.PROFILE_IMAGE_ENTITY_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Component
+public class ProfileImageHelper {
+    private final ProfileImageRepository profileImageRepository;
+
+    public ProfileImage findProfileImageByIdOrElseThrow(Long profileImageId) {
+        return profileImageRepository.findById(profileImageId)
+                .orElseThrow(() -> new EntityNotFoundException(PROFILE_IMAGE_ENTITY_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/member/service/GetMemberInfoService.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/service/GetMemberInfoService.java
@@ -17,7 +17,7 @@ public class GetMemberInfoService {
     private final MemberMapper memberMapper;
 
     public MemberInfoResDto execute(Long memberId) {
-        MemberInfo memberInfo = memberHelper.findMemberByIdOrElseThrow(memberId);
+        MemberInfo memberInfo = memberHelper.findMemberInfoByIdOrElseThrow(memberId);
         return memberMapper.toMemberInfoResDto(memberInfo);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/member/service/UpdateMemberInfoService.java
+++ b/src/main/java/com/dodok/honeypot/domain/member/service/UpdateMemberInfoService.java
@@ -1,0 +1,40 @@
+package com.dodok.honeypot.domain.member.service;
+
+
+import com.dodok.honeypot.domain.member.dto.info.MemberInfo;
+import com.dodok.honeypot.domain.member.dto.req.MemberUpdateReqDto;
+import com.dodok.honeypot.domain.member.entity.Member;
+import com.dodok.honeypot.domain.member.entity.ProfileImage;
+import com.dodok.honeypot.domain.member.helper.MemberHelper;
+import com.dodok.honeypot.domain.member.helper.ProfileImageHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UpdateMemberInfoService {
+    private final MemberHelper memberHelper;
+    private final ProfileImageHelper profileImageHelper;
+
+    public void execute(Long memberId, MemberUpdateReqDto requestDto) {
+        Member member = memberHelper.findMemberByIdOrElseThrow(memberId);
+        ProfileImage profileImage;
+
+        if (isUpdateRequestProfileImageIdIsNull(requestDto)) {
+            profileImage = member.getProfileImage();
+        }
+        else {
+            profileImage = profileImageHelper.findProfileImageByIdOrElseThrow(requestDto.profileImageId());
+        }
+
+        member.updateMember(requestDto.name(), profileImage);
+    }
+
+    private boolean isUpdateRequestProfileImageIdIsNull(MemberUpdateReqDto requestDto) {
+        return Objects.isNull(requestDto.profileImageId());
+    }
+}

--- a/src/main/java/com/dodok/honeypot/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/dodok/honeypot/global/config/security/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
                 .formLogin((auth) -> auth.disable())
                 .httpBasic((auth) -> auth.disable())
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/api/health", "/api/member/info/*", "/api/member/search")
+                        .requestMatchers("/api/health", "/api/member/info/*", "/api/member/search", "/api/member/*")
                         .permitAll()
                         .anyRequest()
                         .authenticated()

--- a/src/main/java/com/dodok/honeypot/global/utils/UpdateValueUtils.java
+++ b/src/main/java/com/dodok/honeypot/global/utils/UpdateValueUtils.java
@@ -1,0 +1,13 @@
+package com.dodok.honeypot.global.utils;
+
+import java.util.Objects;
+
+public class UpdateValueUtils {
+    public static <T> T updateValue(T currentValue, T newValue) {
+        if (Objects.isNull(newValue)) {
+            return currentValue;
+        } else {
+            return newValue;
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업내용
- 프로필 수정하는 API를 만들었습니다.

## 💬 중점적으로 봐줄 사항
- UpdateValueUtils이 추가 됐는데 Entity를 업데이트할 때 request body에 있는 값은 업데이트 시키고 값이 없으면 기존 값을 유지하게 됩니다. 코드 보시면 뭐하는 놈이구나 파악 가능 하실겁니다.
- memberId를 현재는 path로 받는데 이건 추후 시큐리티 붙으면 수정하겠습니다.
- service 코드에 ProfileImage 받고 null 확인하고 업데이트하는 부분이 좀 지저분한데 개선점 있다면 말씀해주시면 반영하겠습니다.
