### PR TITLE
Dd 56 : 배지 획득 로직 구현(꿀을 받을 때, 꿀을 보낼 때)

### DIFF
--- a/src/main/java/com/dodok/honeypot/domain/badge/dto/CompletedBadgeInfo.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/dto/CompletedBadgeInfo.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
  */
 public record CompletedBadgeInfo(
         Long badgeId,
+        String description,
         LocalDateTime completedDate
 ) {
 }

--- a/src/main/java/com/dodok/honeypot/domain/badge/entity/BadgeComplete.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/entity/BadgeComplete.java
@@ -25,5 +25,12 @@ public class BadgeComplete extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public static BadgeComplete createBadgeComplete(Badge badge, Member member) {
+        return BadgeComplete.builder()
+                .badge(badge)
+                .member(member)
+                .build();
+    }
 }
 

--- a/src/main/java/com/dodok/honeypot/domain/badge/error/BadgeErrorCode.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/error/BadgeErrorCode.java
@@ -1,0 +1,21 @@
+package com.dodok.honeypot.domain.badge.error;
+
+import com.dodok.honeypot.global.error.code.ErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum BadgeErrorCode implements ErrorCode {
+
+    /**
+     * 404 Not Found
+     */
+    BADGE_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "뱃지를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/dodok/honeypot/domain/badge/helper/BadgeCompleteHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/helper/BadgeCompleteHelper.java
@@ -2,8 +2,6 @@ package com.dodok.honeypot.domain.badge.helper;
 
 import com.dodok.honeypot.domain.badge.dto.CompletedBadgeInfo;
 import com.dodok.honeypot.domain.badge.repository.BadgeCompleteRepository;
-import com.dodok.honeypot.domain.member.error.MemberErrorCode;
-import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,17 +14,15 @@ public class BadgeCompleteHelper {
     private final BadgeCompleteRepository badgeCompleteRepository;
 
     /**
-     * 전체 뱃지 + 내가 획득한 뱃지를 조회
+     * 내가 획득한 뱃지를 조회
      * @param memberId 사용자의 memberId
      * @return
      */
     public List<CompletedBadgeInfo> findAllCompletedBadgeByMemberId(Long memberId) {
+        // TODO : 존재하지 않는 memberId인 경우 예외처리 하는 로직
         List<CompletedBadgeInfo> completedBadgeInfos
                 = badgeCompleteRepository.findAllCompletedBadgeByMemberId(memberId);
 
-        if(completedBadgeInfos.isEmpty()){
-            throw new EntityNotFoundException(MemberErrorCode.MEMBER_ENTITY_NOT_FOUND);
-        }
         return completedBadgeInfos;
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckBadgeAchievementHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckBadgeAchievementHelper.java
@@ -1,0 +1,73 @@
+package com.dodok.honeypot.domain.badge.helper;
+
+import com.dodok.honeypot.domain.badge.entity.BadgeComplete;
+import com.dodok.honeypot.domain.badge.error.BadgeErrorCode;
+import com.dodok.honeypot.domain.badge.repository.BadgeCompleteRepository;
+import com.dodok.honeypot.domain.badge.repository.BadgeRepository;
+import com.dodok.honeypot.domain.member.error.MemberErrorCode;
+import com.dodok.honeypot.domain.member.repository.MemberRepository;
+import com.dodok.honeypot.domain.praise.repository.ReceivePraiseRepository;
+import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 사용자가 뱃지 획득 조건을 달성했는지 확인하는 헬퍼
+ */
+@RequiredArgsConstructor
+@Component
+public class CheckBadgeAchievementHelper {
+
+    private final BadgeCompleteRepository badgeCompleteRepository;
+    private final BadgeRepository badgeRepository;
+
+    private final ReceivePraiseRepository receivePraiseRepository;
+    private final MemberRepository memberRepository;
+
+    public static final List<Long> GOT_PRAISE_COUNTS = List.of(1L, 7L, 50L);
+    public static final List<String> GOT_PRAISE_DESCRIPTIONS = List.of("받은 꿀 1회", "받은 꿀 7회", "받은 꿀 50회");
+
+    /**
+     * 받은 꿀(칭찬)이 있을 때 배지 달성 조건을 체크하고 업데이트를 진행하는 로직
+     *
+     * @param memberId 사용자의 memberId
+     * @return // TODO : 배지 달성을 했을 때, 사용자(프론트)에게 어떻게 전달할 것인가?
+     */
+    public void updateReceivePraiseBadge(Long memberId) {
+        Long receivedPraiseCount = receivePraiseRepository.countByMember_Id(memberId);
+
+        for (int badgeLevel = 0; badgeLevel < GOT_PRAISE_COUNTS.size(); badgeLevel++) {
+            Long count = GOT_PRAISE_COUNTS.get(badgeLevel);
+            String description = GOT_PRAISE_DESCRIPTIONS.get(badgeLevel);
+
+            if (Objects.equals(receivedPraiseCount, count)) {
+                badgeCompleteRepository.save(
+                        getBadgeComplete(memberId, description)
+                );
+                break;
+            }
+        }
+    }
+
+    /**
+     * BadgeComplete 엔티티를 생성하기 위해 예외처리를 진행하는 로직
+     * @param memberId 사용자의 memberId
+     * @param description 뱃지의 설명란
+     * @return 생성된 BadgeComplete 엔티티
+     */
+    private BadgeComplete getBadgeComplete(Long memberId, String description) {
+        return BadgeComplete.createBadgeComplete(
+                badgeRepository.findByDescription(description).orElseThrow(
+                        () -> new EntityNotFoundException(BadgeErrorCode.BADGE_ENTITY_NOT_FOUND)
+                ),
+                memberRepository.findById(memberId).orElseThrow(
+                        () -> new EntityNotFoundException(MemberErrorCode.MEMBER_ENTITY_NOT_FOUND)
+                )
+        );
+    }
+
+
+}

--- a/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckReceivePraiseBadgeHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckReceivePraiseBadgeHelper.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * 사용자가 뱃지 획득 조건을 달성했는지 확인하는 헬퍼
+ * 사용자가 뱃지 획득 조건을 달성했는지 확인하는 헬퍼 - 칭찬을 받을 때
  */
 @RequiredArgsConstructor
 @Component
-public class CheckBadgeAchievementHelper {
+public class CheckReceivePraiseBadgeHelper {
 
     private final BadgeCompleteRepository badgeCompleteRepository;
     private final BadgeRepository badgeRepository;
@@ -27,8 +27,8 @@ public class CheckBadgeAchievementHelper {
     private final ReceivePraiseRepository receivePraiseRepository;
     private final MemberRepository memberRepository;
 
-    public static final List<Long> GOT_PRAISE_COUNTS = List.of(1L, 7L, 50L);
-    public static final List<String> GOT_PRAISE_DESCRIPTIONS = List.of("받은 꿀 1회", "받은 꿀 7회", "받은 꿀 50회");
+    public static final List<Long> RECEIVE_PRAISE_COUNTS = List.of(1L, 7L, 50L);
+    public static final List<String> RECEIVE_PRAISE_DESCRIPTIONS = List.of("받은 꿀 1회", "받은 꿀 7회", "받은 꿀 50회");
 
     /**
      * 받은 꿀(칭찬)이 있을 때 배지 달성 조건을 체크하고 업데이트를 진행하는 로직
@@ -39,9 +39,9 @@ public class CheckBadgeAchievementHelper {
     public void updateReceivePraiseBadge(Long memberId) {
         Long receivedPraiseCount = receivePraiseRepository.countByMember_Id(memberId);
 
-        for (int badgeLevel = 0; badgeLevel < GOT_PRAISE_COUNTS.size(); badgeLevel++) {
-            Long count = GOT_PRAISE_COUNTS.get(badgeLevel);
-            String description = GOT_PRAISE_DESCRIPTIONS.get(badgeLevel);
+        for (int badgeLevel = 0; badgeLevel < RECEIVE_PRAISE_COUNTS.size(); badgeLevel++) {
+            Long count = RECEIVE_PRAISE_COUNTS.get(badgeLevel);
+            String description = RECEIVE_PRAISE_DESCRIPTIONS.get(badgeLevel);
 
             if (Objects.equals(receivedPraiseCount, count)) {
                 badgeCompleteRepository.save(

--- a/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckSendPraiseBadgeHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckSendPraiseBadgeHelper.java
@@ -1,0 +1,73 @@
+package com.dodok.honeypot.domain.badge.helper;
+
+import com.dodok.honeypot.domain.badge.entity.BadgeComplete;
+import com.dodok.honeypot.domain.badge.error.BadgeErrorCode;
+import com.dodok.honeypot.domain.badge.repository.BadgeCompleteRepository;
+import com.dodok.honeypot.domain.badge.repository.BadgeRepository;
+import com.dodok.honeypot.domain.member.error.MemberErrorCode;
+import com.dodok.honeypot.domain.member.repository.MemberRepository;
+import com.dodok.honeypot.domain.praise.repository.SendPraiseRepository;
+import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 사용자가 뱃지 획득 조건을 달성했는지 확인하는 헬퍼 - 칭찬을 보낼 때
+ */
+@RequiredArgsConstructor
+@Component
+public class CheckSendPraiseBadgeHelper {
+
+    private final BadgeCompleteRepository badgeCompleteRepository;
+    private final BadgeRepository badgeRepository;
+
+    private final SendPraiseRepository sendPraiseRepository;
+    private final MemberRepository memberRepository;
+
+    public static final List<Long> SEND_PRAISE_COUNTS = List.of(1L, 7L, 50L);
+    public static final List<String> SEND_PRAISE_DESCRIPTIONS = List.of("보낸 꿀 1회", "보낸 꿀 7회", "보낸 꿀 50회");
+
+    /**
+     * 보낸 꿀(칭찬)이 있을 때 배지 달성 조건을 체크하고 업데이트를 진행하는 로직
+     *
+     * @param memberId 사용자의 memberId
+     * @return // TODO : 배지 달성을 했을 때, 사용자(프론트)에게 어떻게 전달할 것인가?
+     */
+    public void updateSendPraiseBadge(Long memberId) {
+        Long sendPraiseCount = sendPraiseRepository.countByMember_Id(memberId);
+
+        for (int badgeLevel = 0; badgeLevel < SEND_PRAISE_COUNTS.size(); badgeLevel++) {
+            Long count = SEND_PRAISE_COUNTS.get(badgeLevel);
+            String description = SEND_PRAISE_DESCRIPTIONS.get(badgeLevel);
+
+            if (Objects.equals(sendPraiseCount, count)) {
+                badgeCompleteRepository.save(
+                        getBadgeComplete(memberId, description)
+                );
+                break;
+            }
+        }
+    }
+
+    /**
+     * BadgeComplete 엔티티를 생성하기 위해 예외처리를 진행하는 로직
+     * @param memberId 사용자의 memberId
+     * @param description 뱃지의 설명란
+     * @return 생성된 BadgeComplete 엔티티
+     */
+    private BadgeComplete getBadgeComplete(Long memberId, String description) {
+        return BadgeComplete.createBadgeComplete(
+                badgeRepository.findByDescription(description).orElseThrow(
+                        () -> new EntityNotFoundException(BadgeErrorCode.BADGE_ENTITY_NOT_FOUND)
+                ),
+                memberRepository.findById(memberId).orElseThrow(
+                        () -> new EntityNotFoundException(MemberErrorCode.MEMBER_ENTITY_NOT_FOUND)
+                )
+        );
+    }
+
+
+}

--- a/src/main/java/com/dodok/honeypot/domain/badge/repository/BadgeInfoQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/repository/BadgeInfoQueryRepositoryImpl.java
@@ -20,6 +20,7 @@
 
             return queryFactory.select(Projections.constructor(CompletedBadgeInfo.class,
                             badge.id,
+                            badge.description,
                             badgeComplete.createdAt))
                     .from(badgeComplete)
                     .join(badge).on(badgeComplete.badge.id.eq(badge.id))

--- a/src/main/java/com/dodok/honeypot/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/repository/BadgeRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
     List<AllBadgeInfo> findAllBy();
+
+    // TODO : 뱃지의 description 컬럼에 unique 또는 인덱스 설정
+    Optional<Badge> findByDescription(String description);
 }

--- a/src/main/java/com/dodok/honeypot/domain/badge/service/CheckBadgeAchievementService.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/service/CheckBadgeAchievementService.java
@@ -1,0 +1,34 @@
+package com.dodok.honeypot.domain.badge.service;
+
+import com.dodok.honeypot.domain.badge.dto.AllBadgeInfo;
+import com.dodok.honeypot.domain.badge.dto.CompletedBadgeInfo;
+import com.dodok.honeypot.domain.badge.dto.res.AllBadgeResDto;
+import com.dodok.honeypot.domain.badge.helper.BadgeCompleteHelper;
+import com.dodok.honeypot.domain.badge.helper.BadgeHelper;
+import com.dodok.honeypot.domain.badge.mapper.BadgeCompleteMapper;
+import com.dodok.honeypot.domain.badge.mapper.BadgeMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 로직이 수행될 때 마다, 뱃지 획득 조건을 달성했는지 체크하는 서비스 로직
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CheckBadgeAchievementService {
+    private final BadgeMapper badgeMapper;
+    private final BadgeCompleteMapper badgeCompleteMapper;
+
+    private final BadgeHelper badgeHelper;
+    private final BadgeCompleteHelper badgeCompleteHelper;
+
+    public AllBadgeResDto execute(Long memberId){
+        List<AllBadgeInfo> allBadgeInfo = badgeHelper.getAllBadge();
+        List<CompletedBadgeInfo> completedBadgeInfos = badgeCompleteHelper.findAllCompletedBadgeByMemberId(memberId);
+        return badgeCompleteMapper.toBadgeResDto(allBadgeInfo,completedBadgeInfos);
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/praise/helper/ReceivePraiseHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/helper/ReceivePraiseHelper.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Component;
 public class ReceivePraiseHelper {
 
     private final ReceivePraiseRepository receivePraiseRepository;
+
+    // TODO : 꿀(칭찬)을 받는 로직 구현 시, CheckBadgeAchievementHelper.updateReceivePraiseBadge() 호출할 것.
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/helper/ReceivePraiseHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/helper/ReceivePraiseHelper.java
@@ -10,5 +10,5 @@ public class ReceivePraiseHelper {
 
     private final ReceivePraiseRepository receivePraiseRepository;
 
-    // TODO : 꿀(칭찬)을 받는 로직 구현 시, CheckBadgeAchievementHelper.updateReceivePraiseBadge() 호출할 것.
+    // TODO : 꿀(칭찬)을 받는 로직 구현 시, CheckReceivePraiseBadgeHelper.updateReceivePraiseBadge() 호출할 것.
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/helper/SendPraiseHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/helper/SendPraiseHelper.java
@@ -9,4 +9,7 @@ import org.springframework.stereotype.Component;
 public class SendPraiseHelper {
 
     private final SendPraiseRepository sendPraiseRepository;
+
+    // TODO : 꿀(칭찬)을 보내는 로직 구현 시, CheckSendPraiseBadgeHelper.updateSendPraiseBadge() 호출할 것.
+
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/ReceivePraiseRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/ReceivePraiseRepository.java
@@ -6,6 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReceivePraiseRepository extends JpaRepository<ReceivePraise, Long> {
-
     Long countByMember_Id(Long memberId);
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/ReceivePraiseRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/ReceivePraiseRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReceivePraiseRepository extends JpaRepository<ReceivePraise, Long> {
 
+    Long countByMember_Id(Long memberId);
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/SendPraiseRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/SendPraiseRepository.java
@@ -6,5 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SendPraiseRepository extends JpaRepository<SendPraise, Long> {
+    Long countByMember_Id(Long memberId);
 
 }

--- a/src/test/java/com/dodok/honeypot/domain/badge/helper/BadgeCompleteHelperTest.java
+++ b/src/test/java/com/dodok/honeypot/domain/badge/helper/BadgeCompleteHelperTest.java
@@ -4,6 +4,7 @@ import com.dodok.honeypot.domain.badge.dto.CompletedBadgeInfo;
 import com.dodok.honeypot.domain.badge.repository.BadgeCompleteRepository;
 import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,8 +17,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @ExtendWith(MockitoExtension.class)
 class BadgeCompleteHelperTest {
 
@@ -29,6 +28,8 @@ class BadgeCompleteHelperTest {
 
     @Test
     @DisplayName("memberId로 해당 사용자가 획득한 뱃지의 정보를 조회하기_실패")
+    // TODO : 존재하지 않는 memberId인 경우 예외처리 하는 로직
+    @Disabled
     void findAllCompletedBadgeByMemberId_Fail() {
         // given
         Long memberId = 978965216L;

--- a/src/test/java/com/dodok/honeypot/domain/badge/helper/BadgeCompleteHelperTest.java
+++ b/src/test/java/com/dodok/honeypot/domain/badge/helper/BadgeCompleteHelperTest.java
@@ -52,8 +52,11 @@ class BadgeCompleteHelperTest {
         Long memberId = 1L;
 
         List<CompletedBadgeInfo> completedBadgeInfos = new ArrayList<>();
-        completedBadgeInfos.add(new CompletedBadgeInfo(1L, LocalDateTime.of(2024, 2, 13, 17, 36, 37)));
-        completedBadgeInfos.add(new CompletedBadgeInfo(4L, LocalDateTime.of(2023, 2, 13, 17, 36, 37)));
+        completedBadgeInfos.add(
+                new CompletedBadgeInfo(1L, "받은 꿀 1회",LocalDateTime.of(2024, 2, 13, 17, 36, 37))
+        );
+        completedBadgeInfos.add(
+                new CompletedBadgeInfo(4L, "보낸 꿀 1회",LocalDateTime.of(2023, 2, 13, 17, 36, 37)));
 
         // when
         Mockito.when(badgeCompleteRepository.findAllCompletedBadgeByMemberId(memberId)).thenReturn(completedBadgeInfos);

--- a/src/test/java/com/dodok/honeypot/domain/badge/mapper/BadgeCompleteMapperTest.java
+++ b/src/test/java/com/dodok/honeypot/domain/badge/mapper/BadgeCompleteMapperTest.java
@@ -14,8 +14,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @ExtendWith(MockitoExtension.class)
 class BadgeCompleteMapperTest {
 
@@ -35,8 +33,11 @@ class BadgeCompleteMapperTest {
         allBadgeInfos.add(new AllBadgeInfo(6L, "https://example.com/images/badge6.png", "꿀플루언서", "보낸 꿀 50회"));
 
         List<CompletedBadgeInfo> completedBadgeInfos = new ArrayList<>();
-        completedBadgeInfos.add(new CompletedBadgeInfo(1L, LocalDateTime.of(2024, 2, 13, 17, 36, 37)));
-        completedBadgeInfos.add(new CompletedBadgeInfo(4L, LocalDateTime.of(2023, 2, 13, 17, 36, 37)));
+        completedBadgeInfos.add(
+                new CompletedBadgeInfo(1L, "받은 꿀 1회",LocalDateTime.of(2024, 2, 13, 17, 36, 37))
+        );
+        completedBadgeInfos.add(
+                new CompletedBadgeInfo(4L, "보낸 꿀 1회",LocalDateTime.of(2023, 2, 13, 17, 36, 37)));
 
         List<BadgeResDto> badgeResDtos = new ArrayList<>();
         badgeResDtos.add(BadgeResDto.of("첫 꿀 받기", "받은 꿀 1회", "https://example.com/images/badge1.png", LocalDateTime.of(2024, 2, 13, 17, 36, 37)));

--- a/src/test/java/com/dodok/honeypot/domain/badge/service/GetBadgeInfoServiceTest.java
+++ b/src/test/java/com/dodok/honeypot/domain/badge/service/GetBadgeInfoServiceTest.java
@@ -49,8 +49,11 @@
             allBadgeInfos.add(new AllBadgeInfo(6L, "https://example.com/images/badge6.png", "꿀플루언서", "보낸 꿀 50회"));
 
             List<CompletedBadgeInfo> completedBadgeInfos = new ArrayList<>();
-            completedBadgeInfos.add(new CompletedBadgeInfo(1L, LocalDateTime.of(2024, 2, 13, 17, 36, 37)));
-            completedBadgeInfos.add(new CompletedBadgeInfo(4L, LocalDateTime.of(2023, 2, 13, 17, 36, 37)));
+            completedBadgeInfos.add(
+                    new CompletedBadgeInfo(1L, "받은 꿀 1회",LocalDateTime.of(2024, 2, 13, 17, 36, 37))
+            );
+            completedBadgeInfos.add(
+                    new CompletedBadgeInfo(4L, "보낸 꿀 1회",LocalDateTime.of(2023, 2, 13, 17, 36, 37)));
 
             List<BadgeResDto> badgeResDtos = new ArrayList<>();
             badgeResDtos.add(BadgeResDto.of("첫 꿀 받기", "받은 꿀 1회", "https://example.com/images/badge1.png", LocalDateTime.of(2024, 2, 13, 17, 36, 37)));


### PR DESCRIPTION
## 📝 작업내용
- 꿀을 받을 때, 꿀을 보낼 때 1,7,50 회를 기준으로 배지를 얻는 로직을 헬퍼 계층에 구현
- 꿀을 받고 보내는 로직이 없기 때문에, `unuse` 상태입니다. 추후 꿀을 받고 보내는 로직이 추가될 때 사용할 수 있도록 `TODO`로 표기하였습니다.
- 

## 💬 중점적으로 봐줄 사항
- 꿀을 받고 보내는 서비스 계층에서 호출하는 것으로 생각했습니다. 다만 호출 결과가 현재 `void`인데, 어떻게 하면 사용자에게 잘 전달할 수 있을지 고민해 봐야 합니다. 아이디어 있으면 부탁~!
  - 꿀을 받고 보낼 때 마다 db에 접근하는 것에 영향을 받지 않기 위해, 비동기로 호출하는 것 생각했습니다. 근데 그렇게 하면 응답 결과를  프론트에 어떻게 전달할 지 고민.
  - 굳이 전달하지 않아도 되려나? 획득할때 알림이 나온다는 말이 없다면, 그냥 db에만 반영하는 것도 괜찮을수도,

