### PR TITLE
Dd 52 그룹 삭제 API

### DIFF
--- a/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
+++ b/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
@@ -2,6 +2,7 @@ package com.dodok.honeypot.application.group.controller;
 
 import com.dodok.honeypot.domain.group.dto.req.GroupCreateReqDto;
 import com.dodok.honeypot.domain.group.service.CreateGroupService;
+import com.dodok.honeypot.domain.group.service.DeleteGroupService;
 import com.dodok.honeypot.global.dto.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +15,19 @@ import org.springframework.web.bind.annotation.*;
 public class GroupController {
 
     private final CreateGroupService createGroupService;
+    private final DeleteGroupService deleteGroupService;
 
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createGroup(@RequestParam(name = "id") final Long memberId,
                                                           @RequestBody @Valid final GroupCreateReqDto requestDto) {
         createGroupService.execute(memberId, requestDto);
         return SuccessResponse.created(null);
+    }
+
+    @DeleteMapping({"/{id}"})
+    public ResponseEntity<SuccessResponse<?>> deleteGroup(@RequestParam(name = "id") final Long memberId,
+                                                          @PathVariable(name = "id") final Long groupId) {
+        deleteGroupService.execute(memberId, groupId);
+        return SuccessResponse.ok(null);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/entity/Group.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/entity/Group.java
@@ -1,9 +1,14 @@
 package com.dodok.honeypot.domain.group.entity;
 
 import com.dodok.honeypot.domain.member.entity.Member;
+import com.dodok.honeypot.domain.praise.entity.ReceivePraise;
+import com.dodok.honeypot.domain.praise.entity.SendPraise;
 import com.dodok.honeypot.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -27,6 +32,14 @@ public class Group extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "group", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<SendPraise> sendPraises = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "group", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ReceivePraise> receivePraises = new ArrayList<>();
 
     public static Group createGroup(String name, Member member, Integer groupCount) {
         Group group = Group.builder()

--- a/src/main/java/com/dodok/honeypot/domain/group/error/GroupErrorCode.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/error/GroupErrorCode.java
@@ -11,6 +11,12 @@ import org.springframework.http.HttpStatus;
 public enum GroupErrorCode implements ErrorCode {
 
     /**
+     * 404 Not Found
+     */
+    GROUP_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 그룹을 찾을 수 없습니다."),
+    MEMBER_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자에게서 해당 그룹을 찾을 수 없습니다."),
+
+    /**
      * 409 Conflict
      */
     DUPLICATE_GROUP_NAME(HttpStatus.CONFLICT, "이미 해당 그룹명이 있습니다.");

--- a/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
@@ -5,11 +5,12 @@ import com.dodok.honeypot.domain.group.entity.Group;
 import com.dodok.honeypot.domain.group.repository.GroupRepository;
 import com.dodok.honeypot.domain.member.entity.Member;
 import com.dodok.honeypot.global.error.exception.ConflictException;
+import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import static com.dodok.honeypot.domain.group.entity.Group.createGroup;
-import static com.dodok.honeypot.domain.group.error.GroupErrorCode.DUPLICATE_GROUP_NAME;
+import static com.dodok.honeypot.domain.group.error.GroupErrorCode.*;
 
 @RequiredArgsConstructor
 @Component
@@ -27,5 +28,14 @@ public class GroupHelper {
         Integer groupCount = groupRepository.countByMember(member);
         Group group = createGroup(requestDto.groupName(), member, groupCount);
         groupRepository.save(group);
+    }
+
+    public Group findGroupByMemberAndIdOrElseThrow(Member member, Long groupId) {
+        return groupRepository.findByMemberAndId(member, groupId)
+                .orElseThrow(() -> new EntityNotFoundException(MEMBER_GROUP_NOT_FOUND));
+    }
+
+    public void deleteGroup(Group group) {
+        groupRepository.delete(group);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupRepository.java
@@ -5,9 +5,12 @@ import com.dodok.honeypot.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long> {
 
     int countByMember(Member member);
     boolean existsByMemberAndName(Member member, String name);
+    Optional<Group> findByMemberAndId(Member member, Long id);
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/service/DeleteGroupService.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/service/DeleteGroupService.java
@@ -1,0 +1,26 @@
+package com.dodok.honeypot.domain.group.service;
+
+
+import com.dodok.honeypot.domain.group.entity.Group;
+import com.dodok.honeypot.domain.group.helper.GroupHelper;
+import com.dodok.honeypot.domain.member.entity.Member;
+import com.dodok.honeypot.domain.member.helper.MemberHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class DeleteGroupService {
+
+    private final MemberHelper memberHelper;
+    private final GroupHelper groupHelper;
+
+    public void execute(Long memberId, Long groupId) {
+        Member member = memberHelper.findMemberByIdOrElseThrow(memberId);
+        Group group = groupHelper.findGroupByMemberAndIdOrElseThrow(member, groupId);
+        groupHelper.deleteGroup(group);
+    }
+
+}

--- a/src/main/java/com/dodok/honeypot/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/dodok/honeypot/global/config/security/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
                 .formLogin((auth) -> auth.disable())
                 .httpBasic((auth) -> auth.disable())
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/api/health", "/api/member/info/*", "/api/member/search","/api/member/*", "/api/badge", "/api/group" )
+                        .requestMatchers("/api/health", "/api/member/info/*", "/api/member/search","/api/member/*", "/api/badge", "/api/group", "/api/group/*")
                         .permitAll()
                         .anyRequest()
                         .authenticated()

--- a/src/test/java/com/dodok/honeypot/domain/group/helper/GroupHelperTest.java
+++ b/src/test/java/com/dodok/honeypot/domain/group/helper/GroupHelperTest.java
@@ -1,8 +1,10 @@
 package com.dodok.honeypot.domain.group.helper;
 
+import com.dodok.honeypot.domain.group.entity.Group;
 import com.dodok.honeypot.domain.group.repository.GroupRepository;
 import com.dodok.honeypot.domain.member.entity.Member;
 import com.dodok.honeypot.global.error.exception.ConflictException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,6 +13,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
+import static com.dodok.honeypot.domain.group.entity.Group.createGroup;
 import static com.dodok.honeypot.domain.member.entity.Member.createEmptyMember;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
@@ -25,10 +30,12 @@ public class GroupHelperTest {
     private GroupRepository groupRepository;
 
     private Member member;
+    private Group group;
 
     @BeforeEach
     void setup() {
         member = createEmptyMember();
+        group = createGroup("테스트", member, 1);
     }
 
     @Test
@@ -43,5 +50,20 @@ public class GroupHelperTest {
         // then
         assertThrows(ConflictException.class,
                 () -> groupHelper.validateDuplicateGroupName(member, groupName));
+    }
+
+    @Test
+    @DisplayName("그룹id와 member로 그룹 찾기")
+    void findGroupByMemberAndIdOrElseThrow() {
+        // given
+
+        // when
+        when(groupRepository.findByMemberAndId(member, group.getId())).thenReturn(Optional.ofNullable(group));
+        Group findGroup = groupHelper.findGroupByMemberAndIdOrElseThrow(member, group.getId());
+
+        // then
+        Assertions.assertThat(findGroup).isEqualTo(group);
+
+
     }
 }


### PR DESCRIPTION
## 📝 작업내용
- 그룹 삭제 API를 추가했습니다.
- 그룹이 삭제됐을 때 담겨있는 칭찬들을 삭제하기 위해 orphanRemoval을 true로 추가했습니다.

## 💬 중점적으로 봐줄 사항
- 뭔가 삭제 기능의 경우 통합 테스트가 필요할 것 같은데 나중에 더 찾아보겠습니다.