### PR TITLE
Dd 50 그룹명 수정 API

### DIFF
--- a/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
+++ b/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
@@ -1,8 +1,10 @@
 package com.dodok.honeypot.application.group.controller;
 
 import com.dodok.honeypot.domain.group.dto.req.GroupCreateReqDto;
+import com.dodok.honeypot.domain.group.dto.req.GroupUpdateReqDto;
 import com.dodok.honeypot.domain.group.service.CreateGroupService;
 import com.dodok.honeypot.domain.group.service.DeleteGroupService;
+import com.dodok.honeypot.domain.group.service.UpdateGroupService;
 import com.dodok.honeypot.global.dto.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ public class GroupController {
 
     private final CreateGroupService createGroupService;
     private final DeleteGroupService deleteGroupService;
+    private final UpdateGroupService updateGroupService;
 
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createGroup(@RequestParam(name = "id") final Long memberId,
@@ -28,6 +31,13 @@ public class GroupController {
     public ResponseEntity<SuccessResponse<?>> deleteGroup(@RequestParam(name = "id") final Long memberId,
                                                           @PathVariable(name = "id") final Long groupId) {
         deleteGroupService.execute(memberId, groupId);
+        return SuccessResponse.ok(null);
+    }
+
+    @PatchMapping
+    public ResponseEntity<SuccessResponse<?>> updateGroup(@RequestParam(name = "id") final Long memberId,
+                                                              @RequestBody final GroupUpdateReqDto requestDto) {
+        updateGroupService.execute(memberId, requestDto);
         return SuccessResponse.ok(null);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckReceivePraiseBadgeHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckReceivePraiseBadgeHelper.java
@@ -37,7 +37,7 @@ public class CheckReceivePraiseBadgeHelper {
      * @return // TODO : 배지 달성을 했을 때, 사용자(프론트)에게 어떻게 전달할 것인가?
      */
     public void updateReceivePraiseBadge(Long memberId) {
-        Long receivedPraiseCount = receivePraiseRepository.countByMember_Id(memberId);
+        Long receivedPraiseCount = receivePraiseRepository.countByReceiverId(memberId);
 
         for (int badgeLevel = 0; badgeLevel < RECEIVE_PRAISE_COUNTS.size(); badgeLevel++) {
             Long count = RECEIVE_PRAISE_COUNTS.get(badgeLevel);

--- a/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckSendPraiseBadgeHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckSendPraiseBadgeHelper.java
@@ -37,7 +37,7 @@ public class CheckSendPraiseBadgeHelper {
      * @return // TODO : 배지 달성을 했을 때, 사용자(프론트)에게 어떻게 전달할 것인가?
      */
     public void updateSendPraiseBadge(Long memberId) {
-        Long sendPraiseCount = sendPraiseRepository.countByMember_Id(memberId);
+        Long sendPraiseCount = sendPraiseRepository.countBySenderId(memberId);
 
         for (int badgeLevel = 0; badgeLevel < SEND_PRAISE_COUNTS.size(); badgeLevel++) {
             Long count = SEND_PRAISE_COUNTS.get(badgeLevel);

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/req/GroupCreateReqDto.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/req/GroupCreateReqDto.java
@@ -3,7 +3,7 @@ package com.dodok.honeypot.domain.group.dto.req;
 import jakarta.validation.constraints.Size;
 
 public record GroupCreateReqDto (
-        @Size(min = 2, max = 15, message = "그룹명은 최소 2자 ~ 최대 15자 입니다.")
+        @Size(min = 1, max = 15, message = "15자 이내로 입력해 주세요.")
         String groupName
 ){
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/req/GroupUpdateReqDto.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/req/GroupUpdateReqDto.java
@@ -1,0 +1,10 @@
+package com.dodok.honeypot.domain.group.dto.req;
+
+import jakarta.validation.constraints.Size;
+
+public record GroupUpdateReqDto(
+        Long groupId,
+        @Size(min = 1, max = 15, message = "15자 이내로 입력해 주세요.")
+        String groupName
+){
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/entity/Group.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/entity/Group.java
@@ -1,5 +1,6 @@
 package com.dodok.honeypot.domain.group.entity;
 
+import com.dodok.honeypot.domain.group.dto.req.GroupUpdateReqDto;
 import com.dodok.honeypot.domain.member.entity.Member;
 import com.dodok.honeypot.domain.praise.entity.ReceivePraise;
 import com.dodok.honeypot.domain.praise.entity.SendPraise;
@@ -9,6 +10,8 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.dodok.honeypot.global.utils.UpdateValueUtils.updateValue;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -49,5 +52,9 @@ public class Group extends BaseTimeEntity {
                 .build();
         member.addGroup(group);
         return group;
+    }
+
+    public void updateGroup(GroupUpdateReqDto requestDto) {
+        this.name = updateValue(this.name, requestDto.groupName());
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
@@ -38,4 +38,9 @@ public class GroupHelper {
     public void deleteGroup(Group group) {
         groupRepository.delete(group);
     }
+
+    public Group findGroupByIdOrElseThrow(Long groupId) {
+        return groupRepository.findById(groupId)
+                .orElseThrow(() -> new EntityNotFoundException(GROUP_ENTITY_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/service/UpdateGroupService.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/service/UpdateGroupService.java
@@ -1,0 +1,27 @@
+package com.dodok.honeypot.domain.group.service;
+
+
+import com.dodok.honeypot.domain.group.dto.req.GroupUpdateReqDto;
+import com.dodok.honeypot.domain.group.entity.Group;
+import com.dodok.honeypot.domain.group.helper.GroupHelper;
+import com.dodok.honeypot.domain.member.entity.Member;
+import com.dodok.honeypot.domain.member.helper.MemberHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UpdateGroupService {
+
+    private final MemberHelper memberHelper;
+    private final GroupHelper groupHelper;
+
+    public void execute(Long memberId, GroupUpdateReqDto requestDto) {
+        Member member = memberHelper.findMemberByIdOrElseThrow(memberId);
+        Group group = groupHelper.findGroupByIdOrElseThrow(requestDto.groupId());
+        groupHelper.validateDuplicateGroupName(member, requestDto.groupName());
+        group.updateGroup(requestDto);
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/praise/entity/ReceivePraise.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/entity/ReceivePraise.java
@@ -21,7 +21,7 @@ public class ReceivePraise extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
-    private Member member;
+    private Member receiver;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "send_praise_id", nullable = false)

--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/ReceivePraiseRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/ReceivePraiseRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReceivePraiseRepository extends JpaRepository<ReceivePraise, Long> {
-    Long countByMember_Id(Long memberId);
+    Long countByReceiverId(Long receiverId);
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/SendPraiseRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/SendPraiseRepository.java
@@ -6,6 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SendPraiseRepository extends JpaRepository<SendPraise, Long> {
-    Long countByMember_Id(Long memberId);
+    Long countBySenderId(Long senderId);
 
 }

--- a/src/test/java/com/dodok/honeypot/domain/group/helper/GroupHelperTest.java
+++ b/src/test/java/com/dodok/honeypot/domain/group/helper/GroupHelperTest.java
@@ -4,6 +4,7 @@ import com.dodok.honeypot.domain.group.entity.Group;
 import com.dodok.honeypot.domain.group.repository.GroupRepository;
 import com.dodok.honeypot.domain.member.entity.Member;
 import com.dodok.honeypot.global.error.exception.ConflictException;
+import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,7 +64,31 @@ public class GroupHelperTest {
 
         // then
         Assertions.assertThat(findGroup).isEqualTo(group);
+    }
 
+    @Test
+    @DisplayName("그룹id로 그룹 찾기")
+    void findGroupByIdOrElseThrow() {
+        // given
 
+        // when
+        when(groupRepository.findById(group.getId())).thenReturn(Optional.ofNullable(group));
+        Group findGroup = groupHelper.findGroupByIdOrElseThrow(group.getId());
+
+        // then
+        Assertions.assertThat(findGroup).isEqualTo(group);
+    }
+
+    @Test
+    @DisplayName("그룹id로 그룹 찾기 예외")
+    void findGroupByIdOrElseThrowException() {
+        // given
+
+        // when
+        when(groupRepository.findById(2L)).thenReturn(Optional.ofNullable(null));
+
+        // then
+        assertThrows(EntityNotFoundException.class,
+                () -> groupHelper.findGroupByIdOrElseThrow(2L));
     }
 }

--- a/src/test/java/com/dodok/honeypot/domain/group/helper/GroupHelperTest.java
+++ b/src/test/java/com/dodok/honeypot/domain/group/helper/GroupHelperTest.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import static com.dodok.honeypot.domain.group.entity.Group.createGroup;
 import static com.dodok.honeypot.domain.member.entity.Member.createEmptyMember;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,8 +48,8 @@ public class GroupHelperTest {
         when(groupRepository.existsByMemberAndName(member, groupName)).thenReturn(true);
 
         // then
-        assertThrows(ConflictException.class,
-                () -> groupHelper.validateDuplicateGroupName(member, groupName));
+        Assertions.assertThatThrownBy(() -> groupHelper.validateDuplicateGroupName(member, groupName))
+                .isInstanceOf(ConflictException.class);
     }
 
     @Test
@@ -88,7 +87,7 @@ public class GroupHelperTest {
         when(groupRepository.findById(2L)).thenReturn(Optional.ofNullable(null));
 
         // then
-        assertThrows(EntityNotFoundException.class,
-                () -> groupHelper.findGroupByIdOrElseThrow(2L));
+        Assertions.assertThatThrownBy(() -> groupHelper.findGroupByIdOrElseThrow(2L))
+                .isInstanceOf(EntityNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 📝 작업내용
- 그룹명 수정 API를 추가 했습니다.

## 💬 중점적으로 봐줄 사항
- `SendPraiseRepository`의 `countByMember_Id`를 인식하지 못해 빌드가 되지 않았어서 `countBySenderId`로 수정했습니다.