### PR TITLE
DD-71 내 전체 그룹 조회하기 API

### DIFF
--- a/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
+++ b/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
@@ -4,11 +4,8 @@ import com.dodok.honeypot.domain.group.dto.req.GroupCreateReqDto;
 import com.dodok.honeypot.domain.group.dto.req.GroupOrderUpdateReqDto;
 import com.dodok.honeypot.domain.group.dto.req.GroupUpdateReqDto;
 import com.dodok.honeypot.domain.group.dto.res.CheckGroupNameResDto;
-import com.dodok.honeypot.domain.group.service.CheckGroupNameService;
-import com.dodok.honeypot.domain.group.service.CreateGroupService;
-import com.dodok.honeypot.domain.group.service.DeleteGroupService;
-import com.dodok.honeypot.domain.group.service.UpdateGroupOrderService;
-import com.dodok.honeypot.domain.group.service.UpdateGroupService;
+import com.dodok.honeypot.domain.group.dto.res.GetAllMyGroupResDto;
+import com.dodok.honeypot.domain.group.service.*;
 import com.dodok.honeypot.global.dto.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +22,7 @@ public class GroupController {
     private final UpdateGroupService updateGroupService;
     private final UpdateGroupOrderService updateGroupOrderService;
     private final CheckGroupNameService checkGroupNameService;
+    private final GetAllMyGroupService getAllMyGroupService;
 
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createGroup(@RequestParam(name = "id") final Long memberId,
@@ -59,5 +57,11 @@ public class GroupController {
                                                                @RequestBody final GroupOrderUpdateReqDto requestDto) {
         updateGroupOrderService.execute(memberId, requestDto);
         return SuccessResponse.ok(null);
+    }
+
+    @GetMapping
+    public ResponseEntity<SuccessResponse<?>> getAllMyGroup(@RequestParam(name = "id") final Long memberId) {
+        final GetAllMyGroupResDto response = getAllMyGroupService.execute(memberId);
+        return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/GroupInfo.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/GroupInfo.java
@@ -1,0 +1,9 @@
+package com.dodok.honeypot.domain.group.dto;
+
+public record GroupInfo(
+        Long groupId,
+        String groupName,
+        String memberName,
+        Integer orderIdx
+) {
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/GroupMemberNameInfo.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/GroupMemberNameInfo.java
@@ -1,0 +1,15 @@
+package com.dodok.honeypot.domain.group.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access= AccessLevel.PRIVATE)
+public record GroupMemberNameInfo(
+        String name
+) {
+    public static GroupMemberNameInfo of(String name) {
+        return GroupMemberNameInfo.builder()
+                .name(name)
+                .build();
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/GroupWithMembersInfo.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/GroupWithMembersInfo.java
@@ -1,0 +1,23 @@
+package com.dodok.honeypot.domain.group.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GroupWithMembersInfo(
+        Long groupId,
+        String groupName,
+        Integer orderIdx,
+        List<GroupMemberNameInfo> groupMembers
+) {
+    public static GroupWithMembersInfo of(Long groupId, String groupName, Integer orderIdx, List<GroupMemberNameInfo> groupMembers) {
+        return GroupWithMembersInfo.builder()
+                .groupId(groupId)
+                .groupName(groupName)
+                .orderIdx(orderIdx)
+                .groupMembers(groupMembers)
+                .build();
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/res/GetAllMyGroupResDto.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/res/GetAllMyGroupResDto.java
@@ -1,0 +1,19 @@
+package com.dodok.honeypot.domain.group.dto.res;
+
+import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetAllMyGroupResDto(
+        List<GroupWithMembersInfo> groupWithMembersInfos
+) {
+    public static GetAllMyGroupResDto of(List<GroupWithMembersInfo> groupWithMembersInfos) {
+        return GetAllMyGroupResDto.builder()
+                .groupWithMembersInfos(groupWithMembersInfos)
+                .build();
+
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
@@ -1,5 +1,6 @@
 package com.dodok.honeypot.domain.group.helper;
 
+import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
 import com.dodok.honeypot.domain.group.dto.req.GroupCreateReqDto;
 import com.dodok.honeypot.domain.group.entity.Group;
 import com.dodok.honeypot.domain.group.repository.GroupRepository;
@@ -8,6 +9,8 @@ import com.dodok.honeypot.global.error.exception.ConflictException;
 import com.dodok.honeypot.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static com.dodok.honeypot.domain.group.entity.Group.createGroup;
 import static com.dodok.honeypot.domain.group.error.GroupErrorCode.*;
@@ -46,5 +49,9 @@ public class GroupHelper {
 
     public Boolean checkGroupNameIsExist(Member member, String groupName) {
         return groupRepository.existsByMemberAndName(member, groupName);
+    }
+
+    public List<GroupWithMembersInfo> findGroupInfosByMemberId(Long memberId) {
+        return groupRepository.findGroupInfosByMemberId(memberId);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/mapper/GroupMapper.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/mapper/GroupMapper.java
@@ -1,11 +1,19 @@
 package com.dodok.honeypot.domain.group.mapper;
 
+import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
 import com.dodok.honeypot.domain.group.dto.res.CheckGroupNameResDto;
+import com.dodok.honeypot.domain.group.dto.res.GetAllMyGroupResDto;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class GroupMapper {
     public CheckGroupNameResDto toCheckGroupNameResDto(Boolean isDuplicate) {
         return CheckGroupNameResDto.of(isDuplicate);
+    }
+
+    public GetAllMyGroupResDto toGetAllMyGroupResDto(List<GroupWithMembersInfo> groupInfos) {
+        return GetAllMyGroupResDto.of(groupInfos);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupInfosQueryRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupInfosQueryRepository.java
@@ -1,0 +1,9 @@
+package com.dodok.honeypot.domain.group.repository;
+
+import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
+
+import java.util.List;
+
+public interface GroupInfosQueryRepository {
+    List<GroupWithMembersInfo> findGroupInfosByMemberId(Long memberId);
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupInfosQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupInfosQueryRepositoryImpl.java
@@ -1,0 +1,82 @@
+package com.dodok.honeypot.domain.group.repository;
+
+import com.dodok.honeypot.domain.group.dto.GroupInfo;
+import com.dodok.honeypot.domain.group.dto.GroupMemberNameInfo;
+import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.dodok.honeypot.domain.group.entity.QGroup.group;
+import static com.dodok.honeypot.domain.receivepraise.entity.QReceivePraise.receivePraise;
+import static com.dodok.honeypot.domain.sendpraise.entity.QSendPraise.sendPraise;
+
+@RequiredArgsConstructor
+public class GroupInfosQueryRepositoryImpl implements GroupInfosQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<GroupWithMembersInfo> findGroupInfosByMemberId(Long memberId) {
+        List<GroupInfo> groupInfos = new ArrayList<>();
+        groupInfos.addAll(queryFactory
+                .select(Projections.constructor(GroupInfo.class,
+                        group.id,
+                        group.name,
+                        sendPraise.receiverName,
+                        group.orderIdx
+                ))
+                .from(group)
+                .leftJoin(group.sendPraises, sendPraise)
+                .where(eqMemberId(memberId))
+                .orderBy(group.orderIdx.asc())
+                .fetch()
+        );
+
+        groupInfos.addAll(queryFactory
+                .select(Projections.constructor(GroupInfo.class,
+                        group.id,
+                        group.name,
+                        receivePraise.sendPraise.sender.name,
+                        group.orderIdx
+                ))
+                .from(group)
+                .leftJoin(group.receivePraises, receivePraise)
+                .where(eqMemberId(memberId))
+                .orderBy(group.orderIdx.asc())
+                .fetch()
+        );
+
+        return groupInfos.stream()
+                .collect(Collectors.groupingBy(
+                        GroupInfo::groupId,     // 그룹 id를 통해 Grouping
+                        Collectors.collectingAndThen(
+                                Collectors.toList(),
+                                groupInfo -> GroupWithMembersInfo.of(   // 그룹 id를 통해 묶은 값들 중에 Id, Name, OrderIdx는 공통이니 하나만 뽑고 memberName은 distinct로 중복 허용하지 않고 가져오기
+                                        groupInfo.get(0).groupId(),
+                                        groupInfo.get(0).groupName(),
+                                        groupInfo.get(0).orderIdx(),
+                                        groupInfo.stream()
+                                                .map(GroupInfo::memberName)
+                                                .filter(Objects::nonNull) // null 값을 필터링
+                                                .distinct()
+                                                .map(GroupMemberNameInfo::of)
+                                                .collect(Collectors.toList())
+                                )
+                        )
+                ))
+                .values().stream()
+                .sorted(Comparator.comparing(GroupWithMembersInfo::orderIdx))
+                .collect(Collectors.toList());
+    }
+
+    private BooleanExpression eqMemberId(Long memberId) {
+        return group.member.id.eq(memberId);
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupRepository.java
@@ -8,7 +8,8 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface GroupRepository extends JpaRepository<Group, Long> {
+public interface GroupRepository extends JpaRepository<Group, Long>,
+        GroupInfosQueryRepository{
 
     int countByMember(Member member);
     boolean existsByMemberAndName(Member member, String name);

--- a/src/main/java/com/dodok/honeypot/domain/group/service/GetAllMyGroupService.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/service/GetAllMyGroupService.java
@@ -1,0 +1,28 @@
+package com.dodok.honeypot.domain.group.service;
+
+import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
+import com.dodok.honeypot.domain.group.dto.res.GetAllMyGroupResDto;
+import com.dodok.honeypot.domain.group.helper.GroupHelper;
+import com.dodok.honeypot.domain.group.mapper.GroupMapper;
+import com.dodok.honeypot.domain.member.helper.MemberHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class GetAllMyGroupService {
+
+    private final GroupHelper groupHelper;
+    private final MemberHelper memberHelper;
+    private final GroupMapper groupMapper;
+
+    public GetAllMyGroupResDto execute(Long memberId) {
+        memberHelper.findMemberByIdOrElseThrow(memberId);
+        List<GroupWithMembersInfo> groupInfos = groupHelper.findGroupInfosByMemberId(memberId);
+        return groupMapper.toGetAllMyGroupResDto(groupInfos);
+    }
+}


### PR DESCRIPTION
## 📝 작업내용
- 내 전체 그룹 조회하기 API를 만들었습니다.

## 💬 중점적으로 봐줄 사항
- 그룹 내에 받은 칭찬, 보낸칭찬에서 멤버의 이름을 뽑아와야하다 보니 
**받은 칭찬에서 보낸 사람 이름 조회 쿼리**, **보낸 칭찬에서 받은 사람 이름 조회 쿼리**로 한번씩 총 두번 보내고 groupId를 통해 합쳤습니다. 
- 합치는 코드가 좀 복잡해서 간단한 코멘트 달아뒀습니다.

