### PR TITLE
DD-130 그룹 id로 그룹 이름 및 칭찬 개수 조회 API 및 CORS 추가

### DIFF
--- a/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
+++ b/src/main/java/com/dodok/honeypot/application/group/controller/GroupController.java
@@ -5,6 +5,7 @@ import com.dodok.honeypot.domain.group.dto.req.GroupOrderUpdateReqDto;
 import com.dodok.honeypot.domain.group.dto.req.GroupUpdateReqDto;
 import com.dodok.honeypot.domain.group.dto.res.CheckGroupNameResDto;
 import com.dodok.honeypot.domain.group.dto.res.GetAllMyGroupResDto;
+import com.dodok.honeypot.domain.group.dto.res.GetGroupNameAndPraiseCountResDto;
 import com.dodok.honeypot.domain.group.dto.res.GetSearchGroupNameResDto;
 import com.dodok.honeypot.domain.group.service.*;
 import com.dodok.honeypot.global.auth.MemberId;
@@ -26,6 +27,7 @@ public class GroupController {
     private final CheckGroupNameService checkGroupNameService;
     private final GetAllMyGroupService getAllMyGroupService;
     private final GetSearchGroupNameService getSearchGroupNameService;
+    private final GetGroupNameAndTotalPraiseCountService getGroupNameAndTotalPraiseCountService;
 
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createGroup(@MemberId final Long memberId,
@@ -72,6 +74,13 @@ public class GroupController {
     public ResponseEntity<SuccessResponse<?>> getSearchGroupName(@MemberId final Long memberId,
                                                                  @RequestParam("groupName") final String groupName) {
         final GetSearchGroupNameResDto response = getSearchGroupNameService.execute(memberId, groupName);
+        return SuccessResponse.ok(response);
+    }
+
+    @GetMapping("/info")
+    public ResponseEntity<SuccessResponse<?>> getGroupNameAndTotalPraiseCount(@MemberId final Long memberId,
+                                                                              @RequestParam("groupId") final Long groupId) {
+        final GetGroupNameAndPraiseCountResDto response = getGroupNameAndTotalPraiseCountService.execute(memberId, groupId);
         return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/GroupNamePraiseCountInfo.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/GroupNamePraiseCountInfo.java
@@ -1,0 +1,9 @@
+package com.dodok.honeypot.domain.group.dto;
+
+public record GroupNamePraiseCountInfo(
+        Long groupId,
+        String name,
+        Integer receiveCount,
+        Integer sendCount
+) {
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/dto/res/GetGroupNameAndPraiseCountResDto.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/dto/res/GetGroupNameAndPraiseCountResDto.java
@@ -1,0 +1,19 @@
+package com.dodok.honeypot.domain.group.dto.res;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetGroupNameAndPraiseCountResDto(
+        Long groupId,
+        String groupName,
+        Integer praiseCount
+) {
+    public static GetGroupNameAndPraiseCountResDto of(Long groupId, String groupName, Integer praiseCount) {
+        return GetGroupNameAndPraiseCountResDto.builder()
+                .groupId(groupId)
+                .groupName(groupName)
+                .praiseCount(praiseCount)
+                .build();
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/helper/GroupHelper.java
@@ -1,5 +1,6 @@
 package com.dodok.honeypot.domain.group.helper;
 
+import com.dodok.honeypot.domain.group.dto.GroupNamePraiseCountInfo;
 import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
 import com.dodok.honeypot.domain.group.dto.SearchGroupInfo;
 import com.dodok.honeypot.domain.group.dto.req.GroupCreateReqDto;
@@ -64,5 +65,10 @@ public class GroupHelper {
 
     public List<SearchGroupInfo> findAllGroupByName(Long memberId, String name) {
         return groupRepository.findAllByNameContainsAndMember(memberId, name);
+    }
+
+    public GroupNamePraiseCountInfo findNameAndPraiseCount(Long groupId, Member member) {
+        return groupRepository.findNameAndPraiseCount(groupId, member)
+                .orElseThrow(() -> new EntityNotFoundException(MEMBER_GROUP_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/mapper/GroupMapper.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/mapper/GroupMapper.java
@@ -1,9 +1,11 @@
 package com.dodok.honeypot.domain.group.mapper;
 
+import com.dodok.honeypot.domain.group.dto.GroupNamePraiseCountInfo;
 import com.dodok.honeypot.domain.group.dto.GroupWithMembersInfo;
 import com.dodok.honeypot.domain.group.dto.SearchGroupInfo;
 import com.dodok.honeypot.domain.group.dto.res.CheckGroupNameResDto;
 import com.dodok.honeypot.domain.group.dto.res.GetAllMyGroupResDto;
+import com.dodok.honeypot.domain.group.dto.res.GetGroupNameAndPraiseCountResDto;
 import com.dodok.honeypot.domain.group.dto.res.GetSearchGroupNameResDto;
 import org.springframework.stereotype.Component;
 
@@ -21,5 +23,11 @@ public class GroupMapper {
 
     public GetSearchGroupNameResDto toGetSearchGroupNameResDto(List<SearchGroupInfo> groupInfos) {
         return GetSearchGroupNameResDto.of(groupInfos);
+    }
+
+    public GetGroupNameAndPraiseCountResDto toGetGroupNameAndPraiseCountResDto(GroupNamePraiseCountInfo groupInfo) {
+        return GetGroupNameAndPraiseCountResDto.of(groupInfo.groupId(),
+                groupInfo.name(),
+                groupInfo.receiveCount() + groupInfo.sendCount());
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupNameAndTotalCountQueryRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupNameAndTotalCountQueryRepository.java
@@ -1,0 +1,10 @@
+package com.dodok.honeypot.domain.group.repository;
+
+import com.dodok.honeypot.domain.group.dto.GroupNamePraiseCountInfo;
+import com.dodok.honeypot.domain.member.entity.Member;
+
+import java.util.Optional;
+
+public interface GroupNameAndTotalCountQueryRepository {
+    Optional<GroupNamePraiseCountInfo> findNameAndPraiseCount(Long memberId, Member member);
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupNameAndTotalCountQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupNameAndTotalCountQueryRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.dodok.honeypot.domain.group.repository;
+
+import com.dodok.honeypot.domain.group.dto.GroupNamePraiseCountInfo;
+import com.dodok.honeypot.domain.member.entity.Member;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.dodok.honeypot.domain.group.entity.QGroup.group;
+
+@RequiredArgsConstructor
+public class GroupNameAndTotalCountQueryRepositoryImpl implements GroupNameAndTotalCountQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<GroupNamePraiseCountInfo> findNameAndPraiseCount(Long groupId, Member member) {
+        return Optional.ofNullable(queryFactory.select(Projections.constructor(GroupNamePraiseCountInfo.class,
+                        group.id,
+                        group.name,
+                        group.receivePraises.size(),
+                        group.sendPraises.size()
+
+                ))
+                .from(group)
+                .where(eqGroupId(groupId), eqMember(member))
+                .fetchOne());
+    }
+
+    private BooleanExpression eqMember(Member member) {
+        return group.member.eq(member);
+    }
+
+    private BooleanExpression eqGroupId(Long groupId) {
+        return group.id.eq(groupId);
+    }
+}

--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupRepository.java
@@ -10,7 +10,8 @@ import java.util.Optional;
 @Repository
 public interface GroupRepository extends JpaRepository<Group, Long>,
         GroupInfosQueryRepository,
-        GroupNameSearchQueryRepository{
+        GroupNameSearchQueryRepository,
+        GroupNameAndTotalCountQueryRepository {
     int countByMember(Member member);
     boolean existsByMemberAndName(Member member, String name);
     Optional<Group> findByMemberAndId(Member member, Long id);

--- a/src/main/java/com/dodok/honeypot/domain/group/service/GetGroupNameAndTotalPraiseCountService.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/service/GetGroupNameAndTotalPraiseCountService.java
@@ -1,0 +1,27 @@
+package com.dodok.honeypot.domain.group.service;
+
+import com.dodok.honeypot.domain.group.dto.GroupNamePraiseCountInfo;
+import com.dodok.honeypot.domain.group.dto.res.GetGroupNameAndPraiseCountResDto;
+import com.dodok.honeypot.domain.group.helper.GroupHelper;
+import com.dodok.honeypot.domain.group.mapper.GroupMapper;
+import com.dodok.honeypot.domain.member.entity.Member;
+import com.dodok.honeypot.domain.member.helper.MemberHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class GetGroupNameAndTotalPraiseCountService {
+
+    private final GroupHelper groupHelper;
+    private final MemberHelper memberHelper;
+    private final GroupMapper groupMapper;
+
+    public GetGroupNameAndPraiseCountResDto execute(Long memberId, Long groupId) {
+        Member member = memberHelper.findMemberByIdOrElseThrow(memberId);
+        GroupNamePraiseCountInfo groupInfo = groupHelper.findNameAndPraiseCount(groupId, member);
+        return groupMapper.toGetGroupNameAndPraiseCountResDto(groupInfo);
+    }
+}

--- a/src/main/java/com/dodok/honeypot/global/config/security/CorsConfig.java
+++ b/src/main/java/com/dodok/honeypot/global/config/security/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry corsRegistry) {
         corsRegistry.addMapping("/**")
                 .allowCredentials(true)
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins("http://localhost:3000", "https://dodok-honeypot.com")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH");
     }
 


### PR DESCRIPTION
## 📝 작업내용
- 그룹 id 통해 그룹 이름과 칭찬 개수를 조회하는 API 만들었습니다.

## 💬 중점적으로 봐줄 사항
- 크게 어려운 부분 없습니다!

