### PR TITLE
DD-134 특정 그룹이 받은 꿀도장의 정보 조회 시 stampId 빠져있던 오류 수정

### DIFF
--- a/src/main/java/com/dodok/honeypot/domain/stamp/repository/ReceivedStampByGroupQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/stamp/repository/ReceivedStampByGroupQueryRepositoryImpl.java
@@ -25,6 +25,7 @@ public class ReceivedStampByGroupQueryRepositoryImpl implements ReceivedStampByG
         return queryFactory
                 .select(Projections.constructor(
                         StampDto.class,
+                        honeyStamp.id,
                         honeyStamp.imageUrl,
                         honeyStamp.stampName
                 ))


### PR DESCRIPTION
## 📝 작업내용
- 특정 그룹이 받은 꿀도장의 정보 반환하는 API에서 오류가 발생해 해결했습니다.
- QueryDSL에서 꿀도장의 정보 조회 시 stampId 빠져있어서 추가해서 해결했습니다.