### PR TITLE
DD-140 refactor : accessToken 재발급 로직에서 만료 시간검증하지 않도록 수정

### DIFF
--- a/src/main/java/com/dodok/honeypot/domain/auth/error/AuthErrorCode.java
+++ b/src/main/java/com/dodok/honeypot/domain/auth/error/AuthErrorCode.java
@@ -37,7 +37,7 @@ public enum AuthErrorCode implements ErrorCode {
      * 404 Not Found
      */
     KAKAO_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "카카오로 회원가입 된 유저를 찾을 수 없습니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "유저와 일치하는 엑세스 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "유저와 일치하는 리프레시 토큰을 찾을 수 없습니다."),
     RECEIVER_MAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이메일로 전송된 인증번호가 없거나 만료되었습니다."),
 
     /**

--- a/src/main/java/com/dodok/honeypot/domain/auth/service/KakaoSocialLoginService.java
+++ b/src/main/java/com/dodok/honeypot/domain/auth/service/KakaoSocialLoginService.java
@@ -44,7 +44,7 @@ public class KakaoSocialLoginService {
     }
 
     public ReissueJwtTokenResDto reissue(ReissueJwtTokenReqDto reissueJwtTokenDto) {
-        Long memberId = jwtUtil.getMemberIdFromAccessToken(reissueJwtTokenDto.accessToken());
+        Long memberId = Long.valueOf(jwtUtil.getMemberIdFromPayload(reissueJwtTokenDto.accessToken()));
         RefreshToken refreshToken = refreshTokenHelper.findRefreshTokenOrElseThrow(memberId);
         jwtUtil.verifyMemberRefreshToken(refreshToken.getRefreshToken(), reissueJwtTokenDto.refreshToken());
         return ReissueJwtTokenResDto.of(createJwtToken(memberId));

--- a/src/main/java/com/dodok/honeypot/global/auth/JwtUtil.java
+++ b/src/main/java/com/dodok/honeypot/global/auth/JwtUtil.java
@@ -2,6 +2,8 @@ package com.dodok.honeypot.global.auth;
 
 import com.dodok.honeypot.domain.auth.error.AuthErrorCode;
 import com.dodok.honeypot.global.error.exception.UnauthorizedException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Map;
 
 import static com.dodok.honeypot.domain.auth.error.AuthErrorCode.*;
 
@@ -48,12 +52,12 @@ public class JwtUtil {
     }
 
     // refresh token 발급
-    public String createRefreshToken(){
+    public String createRefreshToken() {
         LocalDateTime localDate = LocalDateTime.now();
         return Jwts.builder()
                 .setHeaderParam("type", "refreshToken")
                 .setIssuedAt(Timestamp.valueOf(localDate))
-                .setExpiration(Timestamp.valueOf(localDate.plusHours(REFRESHTOKEN_VALIDATE_TIME)))
+                .setExpiration(Timestamp.valueOf(localDate.plusSeconds(REFRESHTOKEN_VALIDATE_TIME)))
                 .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -71,6 +75,18 @@ public class JwtUtil {
                 .get("memberId", Long.class);
     }
 
+    public String getMemberIdFromPayload(String accessToken) {
+        String[] parts = accessToken.split("\\.");
+        String payload = new String(Base64.getDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+        try {
+            Map<Long, Object> claims = new ObjectMapper().readValue(payload, Map.class);
+            return claims.get("memberId").toString();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
     public Long getMemberIdFromAuthorizationHeader(String authorizationHeader) {
         String accessToken = authorizationHeader.substring(7);
         return Jwts.parserBuilder()
@@ -80,6 +96,7 @@ public class JwtUtil {
                 .getBody()
                 .get("memberId", Long.class);
     }
+
     public void verifyMemberRefreshToken(String repositoryRefreshToken, String memberRefreshToken) {
         if (!(repositoryRefreshToken.equals(memberRefreshToken)))
             throw new UnauthorizedException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);


### PR DESCRIPTION
## 📝 작업내용
- accessToken 재발급 로직에서 만료 시간 검증하지 않도록 수정했습니다.

## 💬 중점적으로 봐줄 사항
- accessToken 재발급할 때 accessToken 만료 시간을 검증하는 로직이 포함되어 있어서 재발급이 안되고 있었습니다. 해당 부분  JWT 페이로드를 디코딩하도록 수정했습니다.