### PR TITLE
DD-143 그룹 조회 시 받은 칭찬 보낸 칭찬 개수 바뀌던 문제 수정

### DIFF
--- a/src/main/java/com/dodok/honeypot/domain/group/repository/GroupInfosQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/group/repository/GroupInfosQueryRepositoryImpl.java
@@ -54,8 +54,8 @@ public class GroupInfosQueryRepositoryImpl implements GroupInfosQueryRepository 
         List<GroupPraiseCountInfo> groupCountInfo = queryFactory
                 .select(Projections.constructor(GroupPraiseCountInfo.class,
                         group.id,
-                        sendPraise.countDistinct(),
-                        receivePraise.countDistinct()
+                        receivePraise.countDistinct(),
+                        sendPraise.countDistinct()
                 ))
                 .from(group)
                 .leftJoin(group.sendPraises, sendPraise)


### PR DESCRIPTION
## 📝 작업내용
- 그룹 조회 시 받은 칭찬 보낸 칭찬 개수 바뀌던 문제 수정했습니다.

## 💬 중점적으로 봐줄 사항
- 순서만 바꾼거라 크게 없습니다!

