### PR TITLE
DD-157 feat: SendStatus에 단톡/갠톡/혼톡 추가 및 변경에 따른 조회 로직 수정

### DIFF
--- a/src/main/java/com/dodok/honeypot/application/sendpraise/controller/SendPraiseController.java
+++ b/src/main/java/com/dodok/honeypot/application/sendpraise/controller/SendPraiseController.java
@@ -62,6 +62,12 @@ public class SendPraiseController {
 
     }
 
+    /**
+     *
+     * 칭찬 전송 상태를 갱신하는 폴링 api
+     * @param praiseUuid
+     * @return
+     */
     @GetMapping("/check")
     public ResponseEntity<SuccessResponse<?>> getSendPraiseSent(
             @RequestParam(name = "praise-uuid") String praiseUuid

--- a/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckSendPraiseBadgeHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/badge/helper/CheckSendPraiseBadgeHelper.java
@@ -39,6 +39,7 @@ public class CheckSendPraiseBadgeHelper {
      * @return // TODO : 배지 달성을 했을 때, 사용자(프론트)에게 어떻게 전달할 것인가?
      */
     public void updateSendPraiseBadge(Long memberId) {
+        // TODO : SendStatus == SUCCESS로 조건 걸기
         Long sendPraiseCount = sendPraiseRepository.countBySenderId(memberId);
 
         for (int badgeLevel = 0; badgeLevel < SEND_PRAISE_COUNTS.size(); badgeLevel++) {

--- a/src/main/java/com/dodok/honeypot/domain/praise/helper/PraiseHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/helper/PraiseHelper.java
@@ -11,6 +11,6 @@ public class PraiseHelper {
     private final ReceivePraiseRepository receivePraiseRepository;
 
     public MemberPraiseInfo getMemberPraiseInfo(Long memberId) {
-        return receivePraiseRepository.findMemberPraiseInfosByMemberId(memberId);
+        return receivePraiseRepository.findMemberPraiseInfosByMemberIdAndSendStatusIsTrue(memberId);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/MemberPraiseInfoQueryRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/MemberPraiseInfoQueryRepository.java
@@ -3,5 +3,5 @@ package com.dodok.honeypot.domain.praise.repository;
 import com.dodok.honeypot.domain.praise.dto.info.MemberPraiseInfo;
 
 public interface MemberPraiseInfoQueryRepository {
-    MemberPraiseInfo findMemberPraiseInfosByMemberId(Long memberId);
+    MemberPraiseInfo findMemberPraiseInfosByMemberIdAndSendStatusIsTrue(Long memberId);
 }

--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/MemberPraiseInfoQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/MemberPraiseInfoQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.dodok.honeypot.domain.praise.repository;
 
 import com.dodok.honeypot.domain.praise.dto.info.MemberPraiseInfo;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -16,7 +17,7 @@ public class MemberPraiseInfoQueryRepositoryImpl implements MemberPraiseInfoQuer
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public MemberPraiseInfo findMemberPraiseInfosByMemberId(Long memberId) {
+    public MemberPraiseInfo findMemberPraiseInfosByMemberIdAndSendStatusIsTrue(Long memberId) {
         return queryFactory.
                 select(Projections.constructor(MemberPraiseInfo.class,
                         receivePraise.id.countDistinct(),
@@ -27,12 +28,15 @@ public class MemberPraiseInfoQueryRepositoryImpl implements MemberPraiseInfoQuer
                 .leftJoin(receivePraise).on(receivePraise.receiver.eq(member))
                 .leftJoin(sendPraise).on(sendPraise.sender.eq(member))
                 .leftJoin(receivePraise.sendPraise.honeyStamp, honeyStamp)
-                .where(eqMemberId(memberId))
+                .where(eqMemberId(memberId),eqSendPraiseStatusIsTrue())
                 .groupBy(member.id)
                 .fetchOne();
     }
 
     private BooleanExpression eqMemberId(Long memberId) {
         return member.id.eq(memberId);
+    }
+    private BooleanExpression eqSendPraiseStatusIsTrue() {
+        return sendPraise.sendStatus.in(SendStatus.DIRECT, SendStatus.GROUP);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/receivepraise/dto/res/GetReceivedPraiseResDto.java
+++ b/src/main/java/com/dodok/honeypot/domain/receivepraise/dto/res/GetReceivedPraiseResDto.java
@@ -1,5 +1,6 @@
 package com.dodok.honeypot.domain.receivepraise.dto.res;
 
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import lombok.AccessLevel;
 import lombok.Builder;
 
@@ -11,16 +12,18 @@ String senderName,
 String receiverName,
 String groupName,
 Long groupId,
+SendStatus sendStatus,
 String imageUrl
 ) {
     public static GetReceivedPraiseResDto of(
-            String content, String senderName, String receiverName, String groupName, Long groupId, String imageUrl) {
+            String content, String senderName, String receiverName, String groupName, Long groupId, SendStatus sendStatus,String imageUrl) {
         return GetReceivedPraiseResDto.builder()
                 .content(content)
                 .senderName(senderName)
                 .receiverName(receiverName)
                 .groupName(groupName)
                 .groupId(groupId)
+                .sendStatus(sendStatus)
                 .imageUrl(imageUrl)
                 .build();
     }

--- a/src/main/java/com/dodok/honeypot/domain/receivepraise/mapper/ReceivePraiseMapper.java
+++ b/src/main/java/com/dodok/honeypot/domain/receivepraise/mapper/ReceivePraiseMapper.java
@@ -6,6 +6,7 @@ import com.dodok.honeypot.domain.receivepraise.dto.res.GetGroupReceivePraiseResD
 import com.dodok.honeypot.domain.receivepraise.dto.res.GetReceivedPraiseResDto;
 import com.dodok.honeypot.domain.receivepraise.dto.res.ReceivePraiseInfoResDto;
 import com.dodok.honeypot.domain.sendpraise.entity.SendPraise;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.dodok.honeypot.global.dto.PageInfo;
 import org.springframework.stereotype.Component;
 
@@ -15,9 +16,9 @@ import java.util.stream.Collectors;
 @Component
 public class ReceivePraiseMapper {
 
-    public static GetReceivedPraiseResDto getReceivedPraiseResDto(SendPraise sendPraise, Long savedGroupId) {
+    public static GetReceivedPraiseResDto getReceivedPraiseResDto(SendPraise sendPraise, SendStatus sendStatus, Long savedGroupId) {
         return GetReceivedPraiseResDto.of(sendPraise.getContent(), sendPraise.getSender().getName(), sendPraise.getReceiverName(),
-                sendPraise.getGroup().getName(), savedGroupId, sendPraise.getHoneyStamp().getImageUrl());
+                sendPraise.getGroup().getName(), savedGroupId, sendStatus, sendPraise.getHoneyStamp().getImageUrl());
     }
 
     public GetGroupReceivePraiseResDto toGetGroupReceivePraiseResDto(List<ReceivePraiseInfo> receivePraiseInfos, List<ProfileImage> profileImageUrlList, PageInfo pageInfo) {

--- a/src/main/java/com/dodok/honeypot/domain/receivepraise/service/GetReceivedPraiseService.java
+++ b/src/main/java/com/dodok/honeypot/domain/receivepraise/service/GetReceivedPraiseService.java
@@ -7,11 +7,13 @@ import com.dodok.honeypot.domain.receivepraise.entity.ReceivePraise;
 import com.dodok.honeypot.domain.receivepraise.helper.ReceivePraiseHelper;
 import com.dodok.honeypot.domain.receivepraise.mapper.ReceivePraiseMapper;
 import com.dodok.honeypot.domain.sendpraise.entity.SendPraise;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.dodok.honeypot.domain.sendpraise.helper.SendPraiseHelper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -20,19 +22,23 @@ import java.util.Optional;
 @Service
 @Transactional(readOnly = true)
 public class GetReceivedPraiseService {
+    private final List<SendStatus> sendStatuses = Arrays.asList(SendStatus.DIRECT, SendStatus.GROUP, SendStatus.MYSELF);
+
     private final SendPraiseHelper sendPraiseHelper;
     private final MemberHelper memberHelper;
     private final ReceivePraiseHelper receivePraiseHelper;
+
     public GetReceivedPraiseResDto execute(String praiseUuid, Optional<Long> memberId) {
-        SendPraise sendPraise = sendPraiseHelper.findByUuidOrElseThrow(praiseUuid);
+        SendPraise sendPraise = sendPraiseHelper.findByUuidAndSendStatusesOrElseThrow(praiseUuid, sendStatuses);
 
         Long savedGroupId = -1L; // 내가 칭찬을 이미 받은 경우, 칭찬이 저장된 그룹의 id
+        SendStatus sendStatus = sendPraise.getSendStatus();
 
         if (memberId.isPresent()) {
-            // 내가 보낸 칭찬인지 확인
+            // 내가 보낸 칭찬인 경우
             if (Objects.equals(sendPraise.getSender().getId(), memberId.get())) {
-                savedGroupId = -2L;
-                return ReceivePraiseMapper.getReceivedPraiseResDto(sendPraise, savedGroupId);
+                sendStatus = SendStatus.MYSELF;
+                return ReceivePraiseMapper.getReceivedPraiseResDto(sendPraise, sendStatus, savedGroupId);
             }
 
             Member receiver = memberHelper.findMemberByIdOrElseThrow(memberId.get());
@@ -47,6 +53,6 @@ public class GetReceivedPraiseService {
             }
         }
 
-        return ReceivePraiseMapper.getReceivedPraiseResDto(sendPraise, savedGroupId);
+        return ReceivePraiseMapper.getReceivedPraiseResDto(sendPraise, sendStatus, savedGroupId);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/receivepraise/service/SaveReceivePraiseService.java
+++ b/src/main/java/com/dodok/honeypot/domain/receivepraise/service/SaveReceivePraiseService.java
@@ -9,18 +9,23 @@ import com.dodok.honeypot.domain.member.helper.MemberHelper;
 import com.dodok.honeypot.domain.receivepraise.dto.req.SaveReceivePraiseReqDto;
 import com.dodok.honeypot.domain.receivepraise.helper.ReceivePraiseHelper;
 import com.dodok.honeypot.domain.sendpraise.entity.SendPraise;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.dodok.honeypot.domain.sendpraise.helper.SendPraiseHelper;
 import com.dodok.honeypot.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class SaveReceivePraiseService {
+    private final List<SendStatus> sendStatuses = Arrays.asList(SendStatus.DIRECT, SendStatus.GROUP, SendStatus.MYSELF);
+
     private final MemberHelper memberHelper;
     private final GroupHelper groupHelper;
     private final ReceivePraiseHelper receivePraiseHelper;
@@ -33,7 +38,7 @@ public class SaveReceivePraiseService {
      */
     public void execute(Long memberId, SaveReceivePraiseReqDto req) {
         Member receiver = memberHelper.findMemberByIdOrElseThrow(memberId);
-        SendPraise sendPraise = sendPraiseHelper.findByUuidOrElseThrow(req.praiseUuid());
+        SendPraise sendPraise = sendPraiseHelper.findByUuidAndSendStatusesOrElseThrow(req.praiseUuid(), sendStatuses);
         Group group = groupHelper.findGroupByIdOrElseThrow(req.groupId());
 
         // 저장하려는 그룹이 사용자가 만든 그룹이 아닌 경우

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/entity/SendPraise.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/entity/SendPraise.java
@@ -62,6 +62,7 @@ public class SendPraise extends BaseTimeEntity {
                 .sender(sender)
                 .group(group)
                 .honeyStamp(honeyStamp)
+                .sendStatus(SendStatus.FAIL)
                 .uuid(UUID.randomUUID().toString())
                 .build();
     }

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/entity/SendStatus.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/entity/SendStatus.java
@@ -1,6 +1,9 @@
 package com.dodok.honeypot.domain.sendpraise.entity;
 
 public enum SendStatus {
-    SUCCESS,
-    FAIL
+    DIRECT,  // 일대일, 오픈일대일 - 성공
+    GROUP,   // 그룹채팅방, 오픈그룹 - 성공
+    MYSELF, // 나와의 채팅 - 실패
+    FAIL,   // 전송실패 - 실패
+
 }

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/helper/SendPraiseHelper.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/helper/SendPraiseHelper.java
@@ -4,6 +4,7 @@ import com.dodok.honeypot.domain.group.entity.Group;
 import com.dodok.honeypot.domain.member.entity.Member;
 import com.dodok.honeypot.domain.sendpraise.dto.SendPraiseInfo;
 import com.dodok.honeypot.domain.sendpraise.entity.SendPraise;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.dodok.honeypot.domain.sendpraise.error.SendPraiseErrorCode;
 import com.dodok.honeypot.domain.sendpraise.repository.SendPraiseRepository;
 import com.dodok.honeypot.domain.stamp.entity.HoneyStamp;
@@ -30,19 +31,23 @@ public class SendPraiseHelper {
 
     /**
      * 보낸 칭찬의 uuid를 통해 보낸 칭찬을 찾는 메서드
+     * SendStatus : ALL
      *
-     * @param uuid
-     * @return
      */
     public SendPraise findByUuidOrElseThrow(String uuid) {
         return sendPraiseRepository.findByUuid(uuid).orElseThrow(
                 () -> new EntityNotFoundException(SendPraiseErrorCode.SEND_PRAISE_ENTITY_NOT_FOUND)
         );
     }
+    public SendPraise findByUuidAndSendStatusesOrElseThrow(String uuid, List<SendStatus> sendStatuses) {
+        return sendPraiseRepository.findByUuidAndSendStatusIn(uuid,sendStatuses).orElseThrow(
+                () -> new EntityNotFoundException(SendPraiseErrorCode.SEND_PRAISE_ENTITY_NOT_FOUND)
+        );
+    }
 
 
     public Page<SendPraiseInfo> getGroupSendPraiseInfos(Long groupId, Pageable pageable) {
-        return sendPraiseRepository.findSendPraiseInfosByGroupId(groupId, pageable);
+        return sendPraiseRepository.findSendPraiseInfosByGroupIdAndSendStatusIsTrue(groupId, pageable);
     }
 
     public SendPraise findByIdOrElseThrow(Long sendPraiseId) {

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/repository/GroupSendPraiseGetInfoQueryRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/repository/GroupSendPraiseGetInfoQueryRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface GroupSendPraiseGetInfoQueryRepository {
-    Page<SendPraiseInfo> findSendPraiseInfosByGroupId(Long groupId, Pageable pageable);
+    Page<SendPraiseInfo> findSendPraiseInfosByGroupIdAndSendStatusIsTrue(Long groupId, Pageable pageable);
 }

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/repository/GroupSendPraiseGetInfoQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/repository/GroupSendPraiseGetInfoQueryRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.dodok.honeypot.domain.sendpraise.repository;
 
 import com.dodok.honeypot.domain.sendpraise.dto.SendPraiseInfo;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -23,7 +24,7 @@ public class GroupSendPraiseGetInfoQueryRepositoryImpl implements GroupSendPrais
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<SendPraiseInfo> findSendPraiseInfosByGroupId(Long groupId, Pageable pageable) {
+    public Page<SendPraiseInfo> findSendPraiseInfosByGroupIdAndSendStatusIsTrue(Long groupId, Pageable pageable) {
         List<SendPraiseInfo> contents = queryFactory.
                 select(Projections.constructor(SendPraiseInfo.class,
                         sendPraise.id,
@@ -35,7 +36,7 @@ public class GroupSendPraiseGetInfoQueryRepositoryImpl implements GroupSendPrais
                 .from(sendPraise)
                 .join(sendPraise.group, group)
                 .join(sendPraise.honeyStamp, honeyStamp)
-                .where(eqGroupId(groupId))
+                .where(eqGroupId(groupId),eqSendPraiseStatusIsTrue())
                 .orderBy(CreatedAtDesc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -45,7 +46,7 @@ public class GroupSendPraiseGetInfoQueryRepositoryImpl implements GroupSendPrais
                 .select(sendPraise.id.countDistinct())
                 .from(sendPraise)
                 .join(sendPraise.group, group)
-                .where(eqGroupId(groupId));
+                .where(eqGroupId(groupId),eqSendPraiseStatusIsTrue());
 
         return PageableExecutionUtils.getPage(contents, pageable, countQuery::fetchCount);
     }
@@ -56,5 +57,8 @@ public class GroupSendPraiseGetInfoQueryRepositoryImpl implements GroupSendPrais
 
     private BooleanExpression eqGroupId(Long groupId) {
         return group.id.eq(groupId);
+    }
+    private BooleanExpression eqSendPraiseStatusIsTrue() {
+        return sendPraise.sendStatus.in(SendStatus.DIRECT, SendStatus.GROUP);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/repository/SendPraiseRepository.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/repository/SendPraiseRepository.java
@@ -1,6 +1,7 @@
 package com.dodok.honeypot.domain.sendpraise.repository;
 
 import com.dodok.honeypot.domain.sendpraise.entity.SendPraise;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,6 +13,7 @@ public interface SendPraiseRepository extends JpaRepository<SendPraise, Long>,
         GroupSendPraiseGetInfoQueryRepository {
     Long countBySenderId(Long senderId);
     Optional<SendPraise> findByUuid(String uuid);
+    Optional<SendPraise> findByUuidAndSendStatusIn(String uuid, List<SendStatus> sendStatuses);
 
     List<SendPraise> findAllByGroupId(Long groupId);
 }

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/service/CheckSendPraiseSentService.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/service/CheckSendPraiseSentService.java
@@ -7,16 +7,19 @@ import com.dodok.honeypot.domain.sendpraise.helper.SendPraiseHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class CheckSendPraiseSentService {
     private final SendPraiseHelper sendPraiseHelper;
     public void execute(CheckSendPraiseSentReqDto req) {
         SendPraise sendPraise = sendPraiseHelper.findByUuidOrElseThrow(req.praiseUuid());
         sendPraise.updateSendStatus(SendStatus.SUCCESS);
-        log.info("praise Uuid : "+req.praiseUuid() + "is Successfully Sent");
-        log.info("requestBody : " + req);
+        log.info("[kakao-talk callback api] requestBody praiseUuid: " + req.praiseUuid());
+        log.info("[kakao-talk callback api] requestBody CHAT_TYPE: " + req.CHAT_TYPE());
+        log.info("[kakao-talk callback api] requestBody HASH_CHAT_ID: " + req.HASH_CHAT_ID());
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/service/CheckSendPraiseSentService.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/service/CheckSendPraiseSentService.java
@@ -14,10 +14,24 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class CheckSendPraiseSentService {
+    public static final String MEMO_CHAT = "MemoChat"; // 나와의 채팅방
+    public static final String DIRECT_CHAT = "DirectChat"; // 다른 사용자와의 1:1 채팅방
+    public static final String MULTI_CHAT = "MultiChat"; // 다른 사용자들과의 그룹 채팅방
+    public static final String OPEN_DIRECT_CHAT = "OpenDirectChat"; // 1:1 오픈채팅방
+    public static final String OPEN_MULTI_CHAT = "OpenMultiChat"; // 그룹 오픈채팅방4
+
     private final SendPraiseHelper sendPraiseHelper;
     public void execute(CheckSendPraiseSentReqDto req) {
         SendPraise sendPraise = sendPraiseHelper.findByUuidOrElseThrow(req.praiseUuid());
-        sendPraise.updateSendStatus(SendStatus.SUCCESS);
+        SendStatus newStatus = switch (req.CHAT_TYPE()) {
+            case MEMO_CHAT -> SendStatus.MYSELF;
+            case DIRECT_CHAT, OPEN_DIRECT_CHAT -> SendStatus.DIRECT;
+            case MULTI_CHAT, OPEN_MULTI_CHAT -> SendStatus.GROUP;
+            default -> SendStatus.FAIL;
+        };
+
+        sendPraise.updateSendStatus(newStatus);
+
         log.info("[kakao-talk callback api] requestBody praiseUuid: " + req.praiseUuid());
         log.info("[kakao-talk callback api] requestBody CHAT_TYPE: " + req.CHAT_TYPE());
         log.info("[kakao-talk callback api] requestBody HASH_CHAT_ID: " + req.HASH_CHAT_ID());

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/service/CreateSendPraiseService.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/service/CreateSendPraiseService.java
@@ -29,7 +29,7 @@ public class CreateSendPraiseService {
     private final SendPraiseMapper sendPraiseMapper;
 
     /**
-     * 전송 할 보낸칭찬을 생성하는 로직g
+     * 전송 할 보낸칭찬을 생성하는 로직
      * @param req 보낸칭찬을 만들기 위한 정보들
      * @return 만들어진 보낸칭찬의 uuid
      */

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/service/GetSendPraiseSentService.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/service/GetSendPraiseSentService.java
@@ -2,7 +2,6 @@ package com.dodok.honeypot.domain.sendpraise.service;
 
 import com.dodok.honeypot.domain.sendpraise.dto.res.GetSendPraiseSentResDto;
 import com.dodok.honeypot.domain.sendpraise.entity.SendPraise;
-import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.dodok.honeypot.domain.sendpraise.helper.SendPraiseHelper;
 import com.dodok.honeypot.domain.sendpraise.mapper.SendPraiseMapper;
 import lombok.RequiredArgsConstructor;
@@ -12,14 +11,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class GetSendPraiseSentService {
     private final SendPraiseHelper sendPraiseHelper;
     private final SendPraiseMapper sendPraiseMapper;
     public GetSendPraiseSentResDto execute(String praiseUuid) {
         SendPraise sendPraise = sendPraiseHelper.findByUuidOrElseThrow(praiseUuid);
-        sendPraise.updateSendStatus(SendStatus.SUCCESS);
         return sendPraiseMapper.toGetSendPraiseSentResDto(sendPraise);
     }
 }

--- a/src/main/java/com/dodok/honeypot/domain/sendpraise/service/GetSendPraiseSentService.java
+++ b/src/main/java/com/dodok/honeypot/domain/sendpraise/service/GetSendPraiseSentService.java
@@ -2,20 +2,24 @@ package com.dodok.honeypot.domain.sendpraise.service;
 
 import com.dodok.honeypot.domain.sendpraise.dto.res.GetSendPraiseSentResDto;
 import com.dodok.honeypot.domain.sendpraise.entity.SendPraise;
+import com.dodok.honeypot.domain.sendpraise.entity.SendStatus;
 import com.dodok.honeypot.domain.sendpraise.helper.SendPraiseHelper;
 import com.dodok.honeypot.domain.sendpraise.mapper.SendPraiseMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class GetSendPraiseSentService {
     private final SendPraiseHelper sendPraiseHelper;
     private final SendPraiseMapper sendPraiseMapper;
     public GetSendPraiseSentResDto execute(String praiseUuid) {
         SendPraise sendPraise = sendPraiseHelper.findByUuidOrElseThrow(praiseUuid);
+        sendPraise.updateSendStatus(SendStatus.SUCCESS);
         return sendPraiseMapper.toGetSendPraiseSentResDto(sendPraise);
     }
 }


### PR DESCRIPTION
## 📝 작업내용
- `SendStatus`가 다음처럼 변경되었습니다.
![image](https://github.com/user-attachments/assets/000296e7-8ebc-430e-8c32-8de5b3b851cf)
- `SendStatus` == `FAIL`이 아닌 값에 대해서만 조회할 수 있도록 수정
- 보낸칭찬 조회시, `SendStatus`가 `GROUP` 또는 `MYSELF` 또는 `DIRECT`일 때 응답 값을 변화시킴

## 💬 중점적으로 봐줄 사항
- 어렵습니다..

