### PR TITLE
DD-164 fix : 보낸 칭찬이 없을 때도 검색 잘되도록 쿼리 수정

### DIFF
--- a/src/main/java/com/dodok/honeypot/domain/praise/repository/MemberPraiseInfoQueryRepositoryImpl.java
+++ b/src/main/java/com/dodok/honeypot/domain/praise/repository/MemberPraiseInfoQueryRepositoryImpl.java
@@ -26,9 +26,11 @@ public class MemberPraiseInfoQueryRepositoryImpl implements MemberPraiseInfoQuer
                 ))
                 .from(member)
                 .leftJoin(receivePraise).on(receivePraise.receiver.eq(member))
-                .leftJoin(sendPraise).on(sendPraise.sender.eq(member))
+                .leftJoin(sendPraise).on(sendPraise.sender.eq(member)
+                        .and(eqSendPraiseStatusIsTrue())
+                        .and(eqSendPraiseGroupIsNotDeleted()))
                 .leftJoin(receivePraise.sendPraise.honeyStamp, honeyStamp)
-                .where(eqMemberId(memberId),eqSendPraiseStatusIsTrue(),eqSendPraiseGroupIsNotDeleted())
+                .where(eqMemberId(memberId))
                 .fetchOne();
     }
 


### PR DESCRIPTION
## 📝 작업내용
- 보낸 칭찬이 없을 때도 검색 잘되도록 쿼리 수정

## 💬 중점적으로 봐줄 사항
- where의 조건을 sendPraise의 on절로 옮겼습니다.

